### PR TITLE
fix: draw over objects temporarily with pressing Ctrl

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -5562,7 +5562,7 @@ class guiWin(QMainWindow):
         if self.isRightClickDragImg1 and self.curvToolButton.isChecked():
             self.drawAutoContour(y, x)
 
-        # Brush dragging mouse --> keep painting
+        # Brush dragging mouse --> keep brushing
         elif self.isMouseDragImg1 and self.brushButton.isChecked():
             lab_2D = self.get_2Dlab(posData.lab)
 
@@ -5579,13 +5579,12 @@ class guiWin(QMainWindow):
             mask = np.zeros(lab_2D.shape, bool)
             mask[diskSlice][diskMask] = True
             mask[rrPoly, ccPoly] = True
-
-            # If user double-pressed 'b' then draw over the labels
-            color = self.brushButton.palette().button().color().name()
-            drawUnder = color != self.doublePressKeyButtonColor
+            
+            modifiers = QGuiApplication.keyboardModifiers()
+            ctrl = modifiers == Qt.ControlModifier
 
             # t3 = time.perf_counter()
-            if drawUnder:
+            if not self.isPowerBrush() and not ctrl:
                 mask[lab_2D!=0] = False
                 self.setHoverToolSymbolColor(
                     xdata, ydata, self.ax2_BrushCirclePen,


### PR DESCRIPTION
Pressing Ctrl while drawing object with brush was broken. 