### PR TITLE
Adds "Cell-ACDC" string item to QApplication argv

### DIFF
--- a/cellacdc/_run.py
+++ b/cellacdc/_run.py
@@ -321,7 +321,7 @@ def _setup_app(splashscreen=False, icon_path=None, logo_path=None, scheme=None):
     from qtpy.QtGui import QPalette, QIcon
     from . import settings_csv_path, resources_folderpath
     
-    app = QApplication([])
+    app = QApplication(['Cell-ACDC'])
     app.setStyle(QStyleFactory.create('Fusion'))
     is_OS_dark_mode = app.palette().color(QPalette.Window).getHsl()[2] < 100
     app.toggle_dark_mode = False


### PR DESCRIPTION
This is needed to avoid that upon clicking on the Cell-ACDC icon in a virtual desktop environment, such as abcdesktop and bard, a new instance of the app is created instead of showing the already opened one. 