### PR TITLE
fix: call get_pytorch_command as a function in InstallPyTorchDialog

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -14588,7 +14588,7 @@ class InstallPyTorchDialog(QBaseDialog):
         osText = self.osCombobox.currentText()
         pkgManager = self.pkgManagerCombobox.currentText()
         cmptPlatform = self.cmptPlatformCombobox.currentText()
-        command = myutils.get_pytorch_command[osText][pkgManager][cmptPlatform]
+        command = myutils.get_pytorch_command()[osText][pkgManager][cmptPlatform]
         self.commandWidget.setCommand(command)
     
     def ok_cb(self):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -22485,7 +22485,7 @@ class guiWin(QMainWindow):
             if lab is not None:
                 # Visited frame
                 posData.frame_i = i
-                self.get_data()
+                self.get_data(lin_tree_init=False)
                 if self.onlyTracking:
                     self.tracking(enforce=True)
                 elif not posData.IDs:


### PR DESCRIPTION
Fixes the following error 

```shell
File "C:\Users\Temporary\Cell_ACDC\cellacdc\models\YeaZ_v2\__init__.py", line 3, in <module>
    myutils.check_install_yeaz()
  File "C:\Users\Temporary\Cell_ACDC\cellacdc\myutils.py", line 2752, in check_install_yeaz
    check_install_torch()
  File "C:\Users\Temporary\Cell_ACDC\cellacdc\myutils.py", line 2871, in check_install_torch
    win = apps.InstallPyTorchDialog(parent=qparent, caller_name=caller_name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Temporary\Cell_ACDC\cellacdc\apps.py", line 14585, in __init__
    self.updateCommand()
  File "C:\Users\Temporary\Cell_ACDC\cellacdc\apps.py", line 14591, in updateCommand
    command = myutils.get_pytorch_command[osText][pkgManager][cmptPlatform]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
TypeError: 'function' object is not subscriptable
```