### PR TITLE
Adds Timon Stegmaier to core developers and fixes docs deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ A GUI-based Python framework for **segmentation**, **tracking**, **cell cycle an
 
 *Written in Python 3 by* \ `Francesco Padovani <https://github.com/ElpadoCan>`__ \ *and* \ `Benedikt Mairhoermann <https://github.com/Beno71>`__\ *.*
 
+*Core developers:* `Francesco Padovani <https://github.com/ElpadoCan>`__, `Timon Stegmaier <https://github.com/Teranis>`__, \ *and* \ `Benedikt Mairhoermann <https://github.com/Beno71>`__\ *.*
+
 .. |build_win_pyqt5| image:: https://github.com/SchmollerLab/Cell_ACDC/actions/workflows/build-windows_pyqt5.yml/badge.svg
    :target: https://github.com/SchmollerLab/Cell_ACDC/actions/workflows/build-windows_pyqt5.yml
    :alt: Build Status (Windows PyQt5)

--- a/cellacdc/docs/requirements.txt
+++ b/cellacdc/docs/requirements.txt
@@ -1,6 +1,7 @@
 sphinx==7.1.2
 sphinx-rtd-theme==1.3.0rc1
 sphinx-copybutton==0.5.2
+readme-renderer==43.0
 sphinxcontrib-email
 sphinx-tabs
 sphinx-carousel

--- a/cellacdc/docs/source/index.rst
+++ b/cellacdc/docs/source/index.rst
@@ -17,6 +17,8 @@ A GUI-based Python framework for **segmentation**, **tracking**, **cell cycle an
 
 *Written in Python 3 by* \ `Francesco Padovani <https://github.com/ElpadoCan>`__ \ *and* \ `Benedikt Mairhoermann <https://github.com/Beno71>`__\ *.*
 
+*Core developers:* `Francesco Padovani <https://github.com/ElpadoCan>`__, `Timon Stegmaier <https://github.com/Teranis>`__, \ *and* \ `Benedikt Mairhoermann <https://github.com/Beno71>`__\ *.*
+
 .. |build_win_pyqt5| image:: https://github.com/SchmollerLab/Cell_ACDC/actions/workflows/build-windows_pyqt5.yml/badge.svg
    :target: https://github.com/SchmollerLab/Cell_ACDC/actions/workflows/build-windows_pyqt5.yml
    :alt: Build Status (Windows PyQt5)


### PR DESCRIPTION
Timon Stegmaier added as core developer on the docs

The latest readme-renderer 44.0 requires `docutils>=0.21.2` but installing from `cellacdc/docs/requirements.txt` currently installs `docutils==0.18`. Therefore with this PR we pin with `readme-renderer==43.0`