### PR TITLE
fix: ask install GPU and stop process correctly

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -8333,7 +8333,6 @@ class guiWin(QMainWindow):
         waitcond.wakeAll()
 
     def SegForLostIDsWorkerFinished(self):
-
         self.updateAllImages()
         self.update_rp()
         self.store_data(autosave=True)

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -301,12 +301,13 @@ class SegForLostIDsWorker(QObject):
         
         init_kwargs = self.guiWin.SegForLostIDsSettings['win'].init_kwargs
         
-        use_gpu = init_kwargs.get('device', 'cpu') != 'cpu'
+        use_gpu = init_kwargs.get('device_type', 'cpu') != 'cpu'
         use_gpu = use_gpu or init_kwargs.get('use_gpu', False)
         
         self.emitSigAskInstallGPU(base_model_name, use_gpu)
         
         if not self.gpu_go:
+            self.signals.finished.emit(self)
             return
         
         if not self.dont_force_cpu:


### PR DESCRIPTION
Correctly stop worker if process of segmenting for lost IDs is stopped from the ask install GPU dialog

Correctly determines if GPU is needed