### PR TITLE
fix: cast None string to None in cellpose base model_path

### DIFF
--- a/cellacdc/models/_cellpose_base/acdcSegment.py
+++ b/cellacdc/models/_cellpose_base/acdcSegment.py
@@ -80,7 +80,12 @@ class Model:
     
         
     def check_model_path_model_type(self, model_path, model_type):
-
+        if model_path == 'None':
+            model_path = None
+        
+        if model_type == 'None':
+            model_type = None
+        
         if model_path is not None and model_type is not None:
             raise TypeError(
                 "You cannot set both `model_type` and `model_path`. "


### PR DESCRIPTION
`model_path` and `model_type `are passed as a string `'None'` to cellacdc.models._cellpose_base.check_model_path_model_type` when running from segm workflow ini file. 

Convert them to actual None in that case. 