### PR TITLE
fix: cast empty string to None in cellpose base model_path

### DIFF
--- a/cellacdc/models/_cellpose_base/acdcSegment.py
+++ b/cellacdc/models/_cellpose_base/acdcSegment.py
@@ -80,10 +80,10 @@ class Model:
     
         
     def check_model_path_model_type(self, model_path, model_type):
-        if model_path == 'None':
+        if model_path == 'None' or not model_path:
             model_path = None
         
-        if model_type == 'None':
+        if model_type == 'None' or not model_type:
             model_type = None
         
         if model_path is not None and model_type is not None:


### PR DESCRIPTION
`model_path` and `model_type` are passed as a empty string to `cellacdc.models._cellpose_base.check_model_path_model_type` when running from segm workflow ini file.

Convert them to actual None in that case.