### PR TITLE
Fix_703, normal division lineage annotations improvements

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -21612,9 +21612,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         except KeyError:
             return        
         
-        # isObjVisible = self.isObjVisible(obj.bbox)
-        # if not isObjVisible:
-        #     return
+        isObjVisible = self.isObjVisible(obj.bbox)
+        if not isObjVisible:
+            return
         
         ccs_ID = cca_df_ID['cell_cycle_stage']
         if ccs_ID == 'G1':

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -12212,8 +12212,13 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
     
     def uncheckAllButtonsFromButtonGroup(self, buttonGroup):
         for button in buttonGroup.buttons():
-            if button.isChecked():
-                button.setChecked(False)
+            if not button.isCheckable():
+                continue
+            
+            if not button.isChecked():
+                continue
+            
+            button.setChecked(False)
     
     @disableWindow
     def changeMode(self, text):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -12210,6 +12210,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         self.setDrawAnnotComboboxText()
         self.prevAnnotOptions = None
     
+    def uncheckAllButtonsFromButtonGroup(self, buttonGroup):
+        for button in buttonGroup.buttons():
+            if button.isChecked():
+                button.setChecked(False)
+    
     @disableWindow
     def changeMode(self, text):
         self.reconnectUndoRedo()
@@ -12228,6 +12233,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             self.lin_tree_ask_changes()
             self.lineage_tree = None
             self.editLin_TreeBar.setVisible(False)
+            self.uncheckAllButtonsFromButtonGroup(self.editLin_TreeGroup)
 
         elif prevMode == 'Cell cycle analysis':
             self.setEnabledCcaToolbar(enabled=False)
@@ -21605,9 +21611,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         except KeyError:
             return        
         
-        isObjVisible = self.isObjVisible(obj.bbox)
-        if not isObjVisible:
-            return
+        # isObjVisible = self.isObjVisible(obj.bbox)
+        # if not isObjVisible:
+        #     return
         
         ccs_ID = cca_df_ID['cell_cycle_stage']
         if ccs_ID == 'G1':

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -17403,6 +17403,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         if result is None:
             self.original_df_lin_tree = None
             self.original_df_lin_tree_i = None
+            self.lin_tree_to_acdc_df(specific={posData.frame_i})
             return
 
         css, txt, differences = result
@@ -21710,15 +21711,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             The ID of the object, by default None.
         """
         if not self.areMothBudLinesRequested(ax):
+            printl('Moth-bud lines not requested for this axis.')
             return
 
         if not ID:
             ID = obj.label
         
         isObjVisible = self.isObjVisible(obj.bbox)
+        printl(isObjVisible)
         
-        if not isObjVisible:
-            return
+        # if not isObjVisible:
+        #     return
 
         scatterItem = self.getMothBudLineScatterItem(ax, isNew)
 

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -1332,7 +1332,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         self.gui_createAnnotateToolbar()
 
     @disableWindow
-    def propagateLinTreeAction(self):
+    def propagateLinTreeAction(self, dummy_for_button=None):
         """
         Propagates the lineage tree based on the current frame_i. Used in self.propagateLinTreeButton.
         """
@@ -21710,6 +21710,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         ID : int, optional
             The ID of the object, by default None.
         """
+        printl('Drawing moth-bud lines...')
         if not self.areMothBudLinesRequested(ax):
             printl('Moth-bud lines not requested for this axis.')
             return

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -21671,7 +21671,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
 
         new_cells = lin_tree_df.index.difference(lin_tree_df_prev.index) # I could use this for the if already but this is probably faster for frames where nothing changes
         if new_cells.shape[0] == 0:
-            self.logger.info('No new cells in the lineage tree for this frame.')
             return
         
         for ax in (0, 1):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -21669,29 +21669,28 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
 
         self.setTitleText()
 
-        if lin_tree_df.shape[0] > lin_tree_df_prev.shape[0]: # check if new cells have arrived
-            new_cells = lin_tree_df.index.difference(lin_tree_df_prev.index) # I could use this for the if already but this is probably faster for frames where nothing changes
-            if new_cells.shape[0] == 0:
-                self.logger.info('No new cells in the lineage tree for this frame.')
-                return
-            
-            for ax in (0, 1):
-                if not self.areMothBudLinesRequested(ax):
+        new_cells = lin_tree_df.index.difference(lin_tree_df_prev.index) # I could use this for the if already but this is probably faster for frames where nothing changes
+        if new_cells.shape[0] == 0:
+            self.logger.info('No new cells in the lineage tree for this frame.')
+            return
+        
+        for ax in (0, 1):
+            if not self.areMothBudLinesRequested(ax):
+                continue
+
+            for ID in new_cells:
+                curr_obj = myutils.get_obj_by_label(rp, ID)
+                lin_tree_df_ID = lin_tree_df.loc[ID]
+
+                # lin_tree_df_mother_ID = lin_tree_df_prev.loc[lin_tree_df_ID["parent_ID_tree"]]
+                if lin_tree_df_ID["parent_ID_tree"] == -1: # make sure that new obj where the parents are not known get skipped
                     continue
+                mother_obj = myutils.get_obj_by_label(prev_rp, lin_tree_df_ID["parent_ID_tree"])
 
-                for ID in new_cells:
-                    curr_obj = myutils.get_obj_by_label(rp, ID)
-                    lin_tree_df_ID = lin_tree_df.loc[ID]
+                emerg_frame_i = lin_tree_df_ID["emerg_frame_i"]
+                isNew = emerg_frame_i == frame_i
 
-                    # lin_tree_df_mother_ID = lin_tree_df_prev.loc[lin_tree_df_ID["parent_ID_tree"]]
-                    if lin_tree_df_ID["parent_ID_tree"] == -1: # make sure that new obj where the parents are not known get skipped
-                        continue
-                    mother_obj = myutils.get_obj_by_label(prev_rp, lin_tree_df_ID["parent_ID_tree"])
-
-                    emerg_frame_i = lin_tree_df_ID["emerg_frame_i"]
-                    isNew = emerg_frame_i == frame_i
-
-                    self.drawObjLin_TreeMothBudLines(ax, curr_obj, mother_obj, isNew, ID=ID)
+                self.drawObjLin_TreeMothBudLines(ax, curr_obj, mother_obj, isNew, ID=ID)
 
     def drawObjLin_TreeMothBudLines(self, ax, obj, mother_obj, isNew, ID=None):
         """
@@ -21710,19 +21709,16 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         ID : int, optional
             The ID of the object, by default None.
         """
-        printl('Drawing moth-bud lines...')
         if not self.areMothBudLinesRequested(ax):
-            printl('Moth-bud lines not requested for this axis.')
             return
 
         if not ID:
             ID = obj.label
         
         isObjVisible = self.isObjVisible(obj.bbox)
-        printl(isObjVisible)
         
-        # if not isObjVisible:
-        #     return
+        if not isObjVisible:
+            return
 
         scatterItem = self.getMothBudLineScatterItem(ax, isNew)
 

--- a/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
+++ b/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
@@ -869,12 +869,14 @@ class normal_division_lineage_tree:
         for i, df in enumerate(df_li):
             if df is None:
                 continue
+            
+            if 'generation_num_tree' not in df.columns:
+                continue
 
-            if not ('generation_num_tree' in df.columns 
-                and not (df['generation_num_tree'] == 0).any()
-                and not df['generation_num_tree'].isnull().any() 
-                and not df["generation_num_tree"].isna().any() 
-                and not df["generation_num_tree"].empty):
+            if ((df['generation_num_tree'] == 0).any()
+                or df['generation_num_tree'].isnull().any() 
+                or df["generation_num_tree"].isna().any() 
+                or df["generation_num_tree"].empty):
                 continue
 
             df = checked_reset_index_Cell_ID(df)

--- a/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
+++ b/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
@@ -870,31 +870,32 @@ class normal_division_lineage_tree:
             if df is None:
                 continue
 
-            if ('generation_num_tree' in df.columns 
+            if not ('generation_num_tree' in df.columns 
                 and not (df['generation_num_tree'] == 0).any()
                 and not df['generation_num_tree'].isnull().any() 
                 and not df["generation_num_tree"].isna().any() 
                 and not df["generation_num_tree"].empty):
+                continue
 
-                df = checked_reset_index_Cell_ID(df)
+            df = checked_reset_index_Cell_ID(df)
 
-                df = filter_cols(df)
-                df = reorg_sister_cells_for_import(df)
-                self.frames_for_dfs.add(i)
-                df_li_new.append(df)
+            df = filter_cols(df)
+            df = reorg_sister_cells_for_import(df)
+            self.frames_for_dfs.add(i)
+            df_li_new.append(df)
 
-                df_filter = df.index.isin(added_IDs)  
-                for root_ID, group in df[df_filter].groupby('root_ID_tree'):
-                    if root_ID not in families_root_IDs:
-                        family = list(zip(group.index, group['generation_num_tree']))
-                        families.append(family)
-                        families_root_IDs.append(root_ID)
-                    else:
-                        # If the root_ID is already in families, we just update the family with the new cells
-                        family_index = families_root_IDs.index(root_ID)
-                        families[family_index].extend(zip(group.index, group['generation_num_tree']))
-                        
-                    added_IDs.update(group.index)
+            df_filter = df.index.isin(added_IDs)  
+            for root_ID, group in df[df_filter].groupby('root_ID_tree'):
+                if root_ID not in families_root_IDs:
+                    family = list(zip(group.index, group['generation_num_tree']))
+                    families.append(family)
+                    families_root_IDs.append(root_ID)
+                else:
+                    # If the root_ID is already in families, we just update the family with the new cells
+                    family_index = families_root_IDs.index(root_ID)
+                    families[family_index].extend(zip(group.index, group['generation_num_tree']))
+                    
+                added_IDs.update(group.index)
                     
         if df_li_new:
             self.lineage_list = df_li_new


### PR DESCRIPTION
- Fixes #703, dont accidently skip if lineage list happens to be same length as previous frame_i one
- Better handling of missing/faulty 'generation_num_tree' in normal_division_lineage_tree.load_lineage_df_list
- lin_tree_ask_changes will now always run lin_tree_to_acdc_df for posData.frame_i
- changeMode() from 'Normal division: Lineage tree' will now try and uncheck all buttons from self.editLin_TreeGroup