### PR TITLE
fix: correctly load video files

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -19,6 +19,12 @@ from typing import Iterable
 KNOWN_EXTENSIONS = (
     '.tif', '.npz', '.npy', '.h5', '.json', '.csv', '.txt'
 )
+IMAGE_EXTENSIONS = (
+    '.tif', '.tiff', '.png', '.jpg', '.jpeg', '.bmp', '.gif',
+)
+VIDEO_EXTENSIONS = (
+    '.mp4', '.avi', '.mov', '.mkv', '.webm', '.flv',
+)
 
 def _warn_ask_install_package(commands: Iterable[str], note_txt=''):
     open_str = '='*100

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -56,6 +56,7 @@ from . import sorted_cols
 from . import io
 from . import core
 from . import whitelist
+from . import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 
 acdc_df_bool_cols = [
     'is_cell_dead',
@@ -1338,12 +1339,16 @@ class loadData:
             self.img_data = np.squeeze(np.load(imgPath))
             self.dset = self.img_data
             self.img_data_shape = self.img_data.shape
-        else:
+        elif self.ext in IMAGE_EXTENSIONS:
             try:
                 self.img_data = np.squeeze(imread(imgPath))
                 self.dset = self.img_data
                 self.img_data_shape = self.img_data.shape
-            except ValueError:
+            except Exception as err:
+                traceback.print_exc()
+                self.criticalExtNotValid(signals=signals)
+        elif self.ext in VIDEO_EXTENSIONS: 
+            try:
                 self.img_data = self._loadVideo(imgPath)
                 self.dset = self.img_data
                 self.img_data_shape = self.img_data.shape


### PR DESCRIPTION
Adds `cellacdc.__init__.IMAGE_EXTENSIONS` and `cellacdc.__init__.VIDEO_EXTENSIONS` 

Checks if loaded file is in `IMAGE_EXTENSIONS` or `VIDEO_EXTENSIONS`