### PR TITLE
build: upgrade numpy to max version for numba at runtime

### DIFF
--- a/cellacdc/__main__.py
+++ b/cellacdc/__main__.py
@@ -60,11 +60,17 @@ def main():
     run()
 
 def run_gui():
-    from ._run import _setup_gui_libraries, _setup_symlink_app_name_macos
+    from ._run import (
+        _setup_gui_libraries, 
+        _setup_symlink_app_name_macos,
+        _setup_numpy
+    )
     
     _setup_symlink_app_name_macos()
     
     _setup_gui_libraries()
+    
+    _setup_numpy()
     
     from qtpy import QtGui, QtWidgets, QtCore
     # from . import qrc_resources

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -39,6 +39,7 @@ if GUI_INSTALLED:
     from . import widgets
     from . import qrc_resources_path, qrc_resources_light_path
     from . import qrc_resources_dark_path
+    from . import whitelist
     
     
 import warnings
@@ -55,7 +56,6 @@ from . import cca_functions
 from . import sorted_cols
 from . import io
 from . import core
-from . import whitelist
 
 acdc_df_bool_cols = [
     'is_cell_dead',

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -2680,7 +2680,7 @@ def check_cellpose_version(version: str):
             cancel = _warnings.warn_installing_different_cellpose_version(
                 version, installed_version
             )
-        if not compare_model_versions(
+        if not is_second_version_greater(
             min_target_versions_cp[str(major_requested)],
             installed_version
         ):
@@ -2705,7 +2705,7 @@ def purge_module(module_name):
     else:
         raise ModuleNotFoundError(f"Module '{module_name}' not found in sys.modules.")
 
-def compare_model_versions(
+def is_second_version_greater(
         target_version: str,
         current_version: str,
 ):
@@ -2717,6 +2717,23 @@ def compare_model_versions(
     current_version = packaging_version.parse(current_version)
     
     return current_version >= target_version
+
+def is_pkg_version_within_range(
+        package_version: str, min_version='', max_version=''
+    ):
+    package_version_number = packaging_version.parse(package_version)
+    is_greater_than_min = True
+    if min_version:
+        min_version_number = packaging_version.parse(min_version)
+        is_greater_than_min = package_version_number >= min_version_number
+    
+    is_less_than_max = True
+    if max_version:
+        max_version_number = packaging_version.parse(max_version)
+        is_less_than_max = package_version_number <= max_version_number
+    
+    return is_greater_than_min and is_less_than_max
+        
 
 def check_install_cellpose(
         version: Literal['2.0', '3.0', '4.0', 'any'] = '2.0', 


### PR DESCRIPTION
After setting up GUI libraries, check if the installed numpy is too recent compared to what numba requires. 

This should be more robust for when numba is installed by a model (e.g., cellpose)