### PR TITLE
improvement: better stretch factors for left column qdialogmodelparams

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -11930,7 +11930,8 @@ class QDialogModelParams(QDialog):
             )
             initParamsStretch = optimalHeightInitParams/heightPreprocParams
             initParamsStretch = max(1, round(initParamsStretch))
-            self.leftColumnLayout.setStretch(2, initParamsStretch)
+            # Set stretch for the "initial parameters" widget at index 2 in the left column layout
+            self.leftColumnLayout.setStretch(LEFT_COLUMN_INIT_PARAMS_INDEX, initParamsStretch)
         if self.postProcessGroupbox is not None:
             heightRight += self.postProcessGroupbox.minimumSizeHint().height()
             heightRight += buttonHeight

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -10781,6 +10781,7 @@ class QDialogModelParams(QDialog):
         initGroupBox.setTitle('')
         leftColumnLayout.addWidget(self.initParamsScrollArea)
         leftColumnLayout.addLayout(initButtonsLayout)
+        self.leftColumnLayout = leftColumnLayout
 
         # RIGHT COLUMN: Segmentation/Eval and Post-processing params
 
@@ -11890,10 +11891,10 @@ class QDialogModelParams(QDialog):
     
     def showEvent(self, event) -> None:
         buttonHeight = self.okButton.minimumSizeHint().height()
-        heightLeft = (
+        heightInitParams = (
             self.initParamsScrollArea.minimumHeightNoScrollbar()
-            + 70 + buttonHeight
         )
+        heightLeft = heightInitParams + 70 + buttonHeight
         heightRight = buttonHeight
         if self.segmentParamsScrollArea is not None:
             heightRight += (
@@ -11905,13 +11906,28 @@ class QDialogModelParams(QDialog):
                 self.extraParamsScrollArea.minimumHeightNoScrollbar()
                 + 70 + buttonHeight
             )
-            
+        
         if self.additionalSegmGroupbox is not None:
             heightRight += self.additionalSegmGroupbox.minimumSizeHint().height()
             heightRight += buttonHeight
         if self.preProcessParamsWidget is not None:
-            heightLeft += self.preProcessParamsWidget.minimumSizeHint().height()
+            heightPreprocParams = (
+                self.preProcessParamsWidget.minimumSizeHint().height()
+            )
+            heightLeft += heightPreprocParams
             heightLeft += buttonHeight
+            self.leftColumnLayout.setStretch(0, 1)
+            
+            heightPreprocessStep = (
+                self.preProcessParamsWidget.stepSizeHeightHint()
+            )
+            heightPreprocessButtons = heightPreprocParams - heightPreprocessStep
+            optimalHeightInitParams = (
+                heightPreprocessButtons + 4*heightPreprocessStep
+            )
+            initParamsStretch = optimalHeightInitParams/heightPreprocParams
+            initParamsStretch = max(1, round(initParamsStretch))
+            self.leftColumnLayout.setStretch(2, initParamsStretch)
         if self.postProcessGroupbox is not None:
             heightRight += self.postProcessGroupbox.minimumSizeHint().height()
             heightRight += buttonHeight
@@ -15368,6 +15384,14 @@ class PreProcessParamsWidget(QWidget):
         
         mainLayout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(mainLayout)
+    
+    def stepSizeHeightHint(self):
+        stepWidgets = self.stepsWidgets[1]
+        height = (
+            stepWidgets['stepLabel'].minimumSizeHint().height()
+            + stepWidgets['selector'].minimumSizeHint().height()
+        )
+        return height
     
     def setChecked(self, checked):
         self.groupbox.setChecked(checked)

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -11926,7 +11926,7 @@ class QDialogModelParams(QDialog):
             )
             heightPreprocessButtons = heightPreprocParams - heightPreprocessStep
             optimalHeightInitParams = (
-                heightPreprocessButtons + 4*heightPreprocessStep
+                heightPreprocessButtons + MAX_PREPROCESS_STEPS*heightPreprocessStep
             )
             initParamsStretch = optimalHeightInitParams/heightPreprocParams
             initParamsStretch = max(1, round(initParamsStretch))

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -93,6 +93,7 @@ POSITIVE_FLOAT_REGEX = float_regex(allow_negative=False)
 TREEWIDGET_STYLESHEET = _palettes.TreeWidgetStyleSheet()
 LISTWIDGET_STYLESHEET = _palettes.ListWidgetStyleSheet()
 BACKGROUND_RGBA = _palettes.get_disabled_colors()['Button']
+MAX_PREPROCESS_STEPS = 4
 
 font = QFont()
 font.setPixelSize(12)
@@ -10737,6 +10738,7 @@ class QDialogModelParams(QDialog):
 
         loadFunc = self.loadLastSelection
         
+        self.initParamsColIndex = 0
         # LEFT COLUMN: Preprocessing and Init params
         preProcessLayout = None
         self.preProcessParamsWidget = None
@@ -10752,6 +10754,7 @@ class QDialogModelParams(QDialog):
             )
             preProcessLayout.addWidget(widgets.QHLine())
             leftColumnLayout.addLayout(preProcessLayout)
+            self.initParamsColIndex += 1
         
         # Init params in left column
         self.initParamsScrollArea = widgets.ScrollArea()
@@ -10778,6 +10781,7 @@ class QDialogModelParams(QDialog):
         initParamsScrollAreaLayout.addWidget(initGroupBox)
         
         leftColumnLayout.addWidget(QLabel(f'<b>{initGroupBox.title()}</b>'))
+        self.initParamsColIndex += 1
         initGroupBox.setTitle('')
         leftColumnLayout.addWidget(self.initParamsScrollArea)
         leftColumnLayout.addLayout(initButtonsLayout)
@@ -11931,7 +11935,9 @@ class QDialogModelParams(QDialog):
             initParamsStretch = optimalHeightInitParams/heightPreprocParams
             initParamsStretch = max(1, round(initParamsStretch))
             # Set stretch for the "initial parameters" widget at index 2 in the left column layout
-            self.leftColumnLayout.setStretch(LEFT_COLUMN_INIT_PARAMS_INDEX, initParamsStretch)
+            self.leftColumnLayout.setStretch(
+                self.initParamsColIndex, initParamsStretch
+            )
         if self.postProcessGroupbox is not None:
             heightRight += self.postProcessGroupbox.minimumSizeHint().height()
             heightRight += buttonHeight

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -11916,6 +11916,9 @@ class QDialogModelParams(QDialog):
             )
             heightLeft += heightPreprocParams
             heightLeft += buttonHeight
+            # Set stretch factor for the widget at index 0 (likely the initial parameters widget)
+            # to ensure it expands appropriately when the window is resized.
+            # A stretch factor of 1 gives it a proportional share of available space.
             self.leftColumnLayout.setStretch(0, 1)
             
             heightPreprocessStep = (


### PR DESCRIPTION
The left column of the layout in `cellacdc.apps.QDialogModelParams` has the preprocessing parameters and the parameters for the initialization of the model. The preprocessing parameters do not need a stretch factor more than 4 steps. This PR implements automatic calculation of an "optimal" stretch factor for better display. 