### PR TITLE
feat/fix: gracefully exit cellpose if something went wrong with model init, cellpose now complains when trying cuda while directml is installed

### DIFF
--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -2165,6 +2165,9 @@ class SegmKernel(_WorkflowKernel):
         self.model = myutils.init_segm_model(
             acdcSegment, posData, self.init_model_kwargs
         )
+        if self.model is None:
+            # The model was not initialized correctly
+            return
         self.is_segment3DT_available = any(
             [name=='segment3DT' for name in dir(self.model)]
         )
@@ -2412,6 +2415,12 @@ class SegmKernel(_WorkflowKernel):
 
         if self.model is None:
             self.init_segm_model(posData)
+        
+        if self.model is None:
+            self.logger_func(
+                f'\nSegmentation model {self.model_name} was not initialized!'
+            )
+            return
         
         """Segmentation routine"""
         self.logger_func(f'\nSegmenting with {self.model_name}...')

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -15932,7 +15932,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
                 self.titleLabel.setText('Segmentation process cancelled.')
                 return
             
-            model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs)            
+            model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs)
+            if model is None:
+                self.logger.info('Segmentation process cancelled.')
+                self.titleLabel.setText('Segmentation process cancelled.')
+                return            
             try:
                 model.setupLogger(self.logger)
             except Exception as e:
@@ -16126,7 +16130,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             self.titleLabel.setText('Segmentation process cancelled.')
             return
 
-        model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs) 
+        model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs)
+        if model is None:
+            self.logger.info('Segmentation process cancelled.')
+            self.titleLabel.setText('Segmentation process cancelled.')
+            return
         try:
             model.setupLogger(self.logger)
         except Exception as e:
@@ -16368,7 +16376,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             return
             
         self.model_kwargs = win.model_kwargs
-        model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs) 
+        model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs)
+        if model is None:
+            self.logger.info('Segmentation process cancelled.')
+            self.titleLabel.setText('Segmentation process cancelled.')
+            return
         try:
             model.setupLogger(self.logger)
         except Exception as e:

--- a/cellacdc/models/_cellpose_base/acdcSegment.py
+++ b/cellacdc/models/_cellpose_base/acdcSegment.py
@@ -612,7 +612,7 @@ def _initialize_image(image:np.ndarray,
 
 def check_directml_gpu_gpu(directml_gpu, gpu, ask_install=True):
     if ask_install:
-        proceed = myutils.check_gpu_available('cellpose_v3', use_gpu=(gpu or directml_gpu))
+        proceed = myutils.check_gpu_available('cellpose_v3', use_gpu=(gpu or directml_gpu), cuda=gpu)
     else:
         proceed = True
 

--- a/cellacdc/models/cellpose_v2/acdcSegment.py
+++ b/cellacdc/models/cellpose_v2/acdcSegment.py
@@ -59,7 +59,7 @@ class Model(CellposeBaseModel):
             Only for v3
 
         """
-
+        self.init_successful = False
         self.initConstants()
         model_type, model_path, device = myutils.translateStrNone(model_type, model_path, device)
         
@@ -95,6 +95,7 @@ class Model(CellposeBaseModel):
                 residual_on=custom_residual_on,
                 diam_mean=custom_diam_mean,
             )
+        self.init_successful = True
     
     def _get_eval_kwargs_v2(
            self,

--- a/cellacdc/models/cellpose_v3/acdcSegment.py
+++ b/cellacdc/models/cellpose_v3/acdcSegment.py
@@ -97,6 +97,7 @@ class Model(CellposeBaseModel):
         """
         self.initConstants(is_rgb=is_rgb)
         self.batch_size = batch_size
+        self.init_successful = False
 
         out = myutils.translateStrNone(model_type, model_path, device,
                                        denoise_model, denoise_model_path, )
@@ -172,6 +173,8 @@ class Model(CellposeBaseModel):
             self,
             directml_gpu,
             gpu, device)
+        
+        self.init_successful = True
 
     def _get_eval_kwargs_v3(
             self,

--- a/cellacdc/models/cellpose_v4/acdcSegment.py
+++ b/cellacdc/models/cellpose_v4/acdcSegment.py
@@ -50,6 +50,7 @@ class Model(CellposeBaseModel):
             Default is 8.
 
         """ 
+        self.init_successful = False
         self.initConstants()
         self.batch_size = batch_size
         model_type, model_path, device = myutils.translateStrNone(model_type, model_path, device)
@@ -84,6 +85,8 @@ class Model(CellposeBaseModel):
             self,
             directml_gpu,
             gpu, device)
+    
+        self.init_successful = False
     
     def _get_eval_kwargs_v4(
             self,

--- a/cellacdc/segm.py
+++ b/cellacdc/segm.py
@@ -610,7 +610,11 @@ class segmWin(QMainWindow):
         if self.secondChannelName is not None:
             init_kwargs['is_rgb'] = True
         
-        self.model = myutils.init_segm_model(acdcSegment, self.posData, init_kwargs) 
+        self.model = myutils.init_segm_model(acdcSegment, self.posData, init_kwargs)
+        if self.model is None:
+            self.logger.info('Segmentation model was not initialized correctly!')
+            self.processStopped()
+            return
         try:
             self.model.setupLogger(self.logger)
         except Exception as e:

--- a/cellacdc/test_segm_model.py
+++ b/cellacdc/test_segm_model.py
@@ -121,6 +121,8 @@ if segm_endname is not None:
 
 
 model = myutils.init_segm_model(acdcSegment, posData, win.init_kwargs)
+if model is None:
+    sys.exit('Segmentation model was not initialized correctly!')
 is_segment3DT_available = any(
     [name=='segment3DT' for name in dir(model)]
 )

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -339,6 +339,13 @@ class SegForLostIDsWorker(QObject):
         args_new = self.guiWin.SegForLostIDsSettings['args_new']
 
         model = myutils.init_segm_model(acdcSegment, posData, init_kwargs_new)
+        if model is None:
+            self.logger.info('Segmentation model was not initialized correctly!')
+            self.signals.critical.emit(
+                (self, 'Segmentation model was not initialized correctly!')
+            )
+            self.signals.finished.emit(self)
+            return
         if self._debug:
             try:
                 model.setupLogger(self.guiwin.logger)


### PR DESCRIPTION
- handle cases where init of segmentation model fails (now returns None as model)
- Not all use cases tested yet but extremly high likelyhood this workds, worst case it crashes like before
- Handle problem where if cuda was selected but directML was installed, acdc did not complain, but then crash alter since cuda stuff was tried