### PR TITLE
Uint-32-conv-in-lab_replace_values

### DIFF
--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -249,7 +249,11 @@ def lab_replace_values(lab, rp, oldIDs, newIDs, in_place=True):
             # Skip assigning ID to same ID
             continue
 
-        lab[obj.slice][obj.image] = newIDs[idx]
+        try:
+            lab[obj.slice][obj.image] = newIDs[idx]
+        except OverflowError:
+            lab = lab.astype(np.uint32) # id
+            lab[obj.slice][obj.image] = newIDs[idx]
     return lab
 
 def post_process_segm(labels, return_delIDs=False, **kwargs):

--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -252,7 +252,8 @@ def lab_replace_values(lab, rp, oldIDs, newIDs, in_place=True):
         try:
             lab[obj.slice][obj.image] = newIDs[idx]
         except OverflowError:
-            lab = lab.astype(np.uint32) # id
+            # it should be uint32 already but sometimes it was not
+            lab = lab.astype(np.uint32) 
             lab[obj.slice][obj.image] = newIDs[idx]
     return lab
 


### PR DESCRIPTION
- sometimes an overflow error was caused by the fact that the input lab to `core.lab_replace_values` was `uint32`, so now that is in a try except which caches overflow error and converts it to uint32