### PR TITLE
chore: removes unnecessary import of qrc_resources

### DIFF
--- a/cellacdc/__main__.py
+++ b/cellacdc/__main__.py
@@ -117,8 +117,7 @@ def run_gui():
     app, splashScreen = _run._setup_app(splashscreen=True)
 
     from cellacdc import myutils, printl
-    from cellacdc import qrc_resources
-
+    
     print('Launching application...')
 
     from cellacdc._main import mainWin

--- a/cellacdc/_main.py
+++ b/cellacdc/_main.py
@@ -59,8 +59,6 @@ from . import exception_handler
 from . import user_profile_path
 from . import cellacdc_path
 
-from . import acdc_qrc_resources
-
 try:
     import spotmax
     from spotmax import _run as spotmaxRun

--- a/cellacdc/_view_all_icons.py
+++ b/cellacdc/_view_all_icons.py
@@ -5,17 +5,6 @@ import shutil
 SCHEME = 'dark' 
 FLAT = True
 
-cellacdc_path = os.path.dirname(os.path.abspath(__file__))
-qrc_resources_light_path = os.path.join(cellacdc_path, 'qrc_resources_light.py')
-qrc_resources_dark_path = os.path.join(cellacdc_path, 'qrc_resources_dark.py')
-qrc_resources_path = os.path.join(cellacdc_path, 'qrc_resources.py')
-os.remove(qrc_resources_path)
-
-if SCHEME == 'dark' and os.path.exists(qrc_resources_dark_path):
-    shutil.copyfile(qrc_resources_dark_path, qrc_resources_path)
-elif SCHEME == 'light' and os.path.exists(qrc_resources_light_path):
-    shutil.copyfile(qrc_resources_light_path, qrc_resources_path)
-
 from qtpy.QtGui import QIcon
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtWidgets import (

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -72,7 +72,7 @@ from . import load, prompts, core, measurements, html_utils
 from . import is_mac, is_win, is_linux, settings_folderpath, config
 from . import preproc_recipes_path, segm_recipes_path
 from . import is_conda_env
-from . import acdc_qrc_resources, printl
+from . import printl
 from . import colors
 from . import issues_url
 from . import myutils

--- a/cellacdc/cca_functions.py
+++ b/cellacdc/cca_functions.py
@@ -18,7 +18,6 @@ from . import GUI_INSTALLED
 if GUI_INSTALLED:
     from qtpy.QtWidgets import QFileDialog
     from . import widgets
-    from . import acdc_qrc_resources
     from . import _run
 
 from . import load, cca_df_colnames

--- a/cellacdc/dataPrep.py
+++ b/cellacdc/dataPrep.py
@@ -34,9 +34,6 @@ from qtpy.compat import getexistingdirectory
 import pyqtgraph as pg
 pg.setConfigOption('imageAxisOrder', 'row-major')
 
-# NOTE: Enable icons
-from . import acdc_qrc_resources
-
 # Custom modules
 from . import exception_handler
 from . import load, prompts, apps, core, myutils

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -37,7 +37,6 @@ from qtpy import QtGui
 # a separate process that doesn't have a parent package
 from . import issues_url
 from . import exception_handler
-from . import acdc_qrc_resources
 from . import apps, myutils, widgets, html_utils, printl
 from . import load, settings_csv_path
 from . import _palettes

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -65,9 +65,6 @@ pg.setConfigOption('imageAxisOrder', 'row-major')
 from warnings import simplefilter
 simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 
-# NOTE: Enable icons
-from . import acdc_qrc_resources
-
 # Custom modules
 from . import exception_handler, disableWindow
 from . import base_cca_dict, lineage_tree_cols, lineage_tree_cols_std_val

--- a/cellacdc/help/about.py
+++ b/cellacdc/help/about.py
@@ -18,7 +18,6 @@ from ..myutils import get_git_pull_checkout_cellacdc_version_commands
 from ..myutils import get_info_version_text
 from .. import widgets, myutils
 from .. import html_utils, printl
-from .. import acdc_qrc_resources
 from .. import cellacdc_path
 
 class QDialogAbout(QDialog):

--- a/cellacdc/help/welcome.py
+++ b/cellacdc/help/welcome.py
@@ -25,7 +25,7 @@ from .. import gui, dataStruct, myutils, cite_url, html_utils, urls, widgets
 from .. import _palettes
 
 # NOTE: Enable icons
-from .. import qrc_resources, cellacdc_path, settings_folderpath
+from .. import cellacdc_path, settings_folderpath
 
 if os.name == 'nt':
     try:

--- a/cellacdc/segm.py
+++ b/cellacdc/segm.py
@@ -31,7 +31,7 @@ import qtpy.compat
 
 # Custom modules
 from . import prompts, load, myutils, apps, core, dataPrep, widgets
-from . import acdc_qrc_resources, html_utils, printl
+from . import html_utils, printl
 from . import exception_handler
 from . import workers
 from . import recentPaths_path

--- a/cellacdc/utils/convert.py
+++ b/cellacdc/utils/convert.py
@@ -35,8 +35,6 @@ from .. import workers
 from .. import cellacdc_path, recentPaths_path, settings_folderpath
 from .. import io
 
-from .. import acdc_qrc_resources
-
 if os.name == 'nt':
     try:
         # Set taskbar icon in windows

--- a/cellacdc/utils/rename.py
+++ b/cellacdc/utils/rename.py
@@ -28,8 +28,6 @@ sys.path.append(cellacdc_path)
 from .. import prompts, load, myutils, apps, html_utils, widgets
 from .. import recentPaths_path, cellacdc_path, settings_folderpath
 
-from .. import acdc_qrc_resources
-
 if os.name == 'nt':
     try:
         # Set taskbar icon in windows

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -58,7 +58,7 @@ import pyqtgraph as pg
 pg.setConfigOption('imageAxisOrder', 'row-major')
 
 from . import myutils, measurements, is_mac, is_win, html_utils, is_linux
-from . import acdc_qrc_resources, printl, settings_folderpath
+from . import printl, settings_folderpath
 from . import colors, config
 from . import html_path
 from . import _palettes


### PR DESCRIPTION
Importing `qrc_resources` is needed only once in `cellacdc.__init__.py`. This PR removes it everwhere else where it's not needed.