### PR TITLE
fix: correctly restore gui window if saving process is cancelled

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29964,13 +29964,21 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         if mode == 'Cell cycle analysis':
             proceed = self.askSaveLastVisitedCcaMode(isQuickSave=isQuickSave)
             if not proceed:
+                self.abortSavingInitialisation()
+                self.setDisabled(False, keepDisabled=False)
+                self.activateWindow()
                 return
         else:
             proceed = self.askSaveLastVisitedSegmMode(isQuickSave=isQuickSave)
             if not proceed:
+                self.abortSavingInitialisation()
+                self.setDisabled(False, keepDisabled=False)
+                self.activateWindow()
                 return
+        
         append_name_og_whitelist, proceed, do_not_save_og_whitelist = self.askSaveOriginalSegm(isQuickSave=isQuickSave)
         if not proceed:
+            self.abortSavingInitialisation()
             self.setDisabled(False, keepDisabled=False)
             self.activateWindow()
             return


### PR DESCRIPTION
Cancelling saving process in the module 3 GUI in some places did not enabled the window back. This PR fixes that