### PR TITLE
Open user profile folder from launcher GUI

### DIFF
--- a/cellacdc/_main.py
+++ b/cellacdc/_main.py
@@ -452,6 +452,8 @@ class mainWin(QMainWindow):
         
         self.settingsMenu = QMenu("&Settings", self)
         self.settingsMenu.addAction(self.changeUserProfileFolderPathAction)
+        self.settingsMenu.addAction(self.openUserProfileFolderAction)
+        self.settingsMenu.addAction(self.openSettingsFolderAction)
         self.settingsMenu.addAction(self.resetUserProfileFolderPathAction)
         menuBar.addMenu(self.settingsMenu)
 
@@ -466,6 +468,7 @@ class mainWin(QMainWindow):
         helpMenu.addAction(self.citeAction)
         helpMenu.addAction(self.contributeAction)
         helpMenu.addAction(self.showLogsAction)
+        helpMenu.addAction(self.openUserProfileFolderAction)
         helpMenu.addSeparator()
         helpMenu.addAction(self.aboutAction)
         if SPOTMAX_INSTALLED:
@@ -811,6 +814,8 @@ class mainWin(QMainWindow):
         self.citeAction = QAction('Cite us...')
         self.contributeAction = QAction('Contribute...')
         self.showLogsAction = QAction('Show log files...')
+        self.openUserProfileFolderAction = QAction('Open user profile path...')
+        self.openSettingsFolderAction = QAction('Open settings folder...')
         self.updateACDCAction = QAction('Update Cell-ACDC...')
         self.updateSPOTMAXAction = QAction('Update SpotMAX...')
         
@@ -900,6 +905,10 @@ class mainWin(QMainWindow):
         )
         self.recentPathsMenu.aboutToShow.connect(self.populateOpenRecent)
         self.showLogsAction.triggered.connect(self.showLogFiles)
+        self.openUserProfileFolderAction.triggered.connect(
+            self.openUserProfileFolder
+        )
+        self.openSettingsFolderAction.triggered.connect(self.openSettingsFolder)
         self.updateACDCAction.triggered.connect(self.launchUpdateACDC)
         if SPOTMAX_INSTALLED:
             self.updateSPOTMAXAction.triggered.connect(self.launchUpdateSpotmax)
@@ -911,6 +920,14 @@ class mainWin(QMainWindow):
         )
         
         self.debugAction.triggered.connect(self._debug)
+    
+    def openSettingsFolder(self):
+        from . import settings_folderpath
+        myutils.showInExplorer(settings_folderpath)
+    
+    def openUserProfileFolder(self):
+        from . import user_profile_path
+        myutils.showInExplorer(user_profile_path)
     
     def showLogFiles(self):
         logs_path = myutils.get_logs_path()

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -502,6 +502,7 @@ def get_info_version_text(is_cli=False, cli_formatted_text=True):
         f'Released on: {release_date}',
         f'Installed in "{cellacdc_path}"',
         f'Environment folder: "{env_folderpath}"',
+        f'User profile folder: "{user_profile_path}"',
         f'Python {python_version}',
         f'Platform: {platform.platform()}',
         f'System: {platform.system()}',


### PR DESCRIPTION
This PR implements the following:

- Open the settings folder path from `Settings --> Open settings folder...` menu on the top menu bar of the Cell-ACDC launcher
- Open the user profile folder path from `Settings --> Open user profile path...` menu on the top menu bar of the Cell-ACDC launcher
- Open the user profile folder path from `Help--> Open user profile path...` menu on the top menu bar of the Cell-ACDC launcher
- Adds the user profile folder path to the text displayed with `acdc -v` command or in the "About Cell-ACDC" window