### PR TITLE
fix: implements #815

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -14059,7 +14059,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             return
 
         if ev.key() == Qt.Key_Q and self.debug:
-            printl(self.autoSaveTimer.isActive())
+            raise TypeError('Debug exception triggered by user.')
 
         if not self.isDataLoaded:
             self.logger.warning(


### PR DESCRIPTION
This PR implements a method to retrieve the release date for those installations of Cell-ACDC installed with `pip install git+`