### PR TITLE
Correctly get position folders, see #836

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -18389,13 +18389,18 @@ class SelectFoldersToAnalyse(QBaseDialog):
         ]
     
     def expFolderToPosFoldernamesMapper(self):
-        expPathsPosFoldernamesMapper = {}
+        expPathsPosFoldernamesMapper = defaultdict(set)
         for selectedPath in self.pathsList():
             pos_foldernames = myutils.get_pos_foldernames(
                 selectedPath, check_if_is_sub_folder=True
             )
             expPath = load.get_exp_path(selectedPath)
-            expPathsPosFoldernamesMapper[expPath] = pos_foldernames
+            expPathsPosFoldernamesMapper[expPath].update(pos_foldernames)
+        
+        expPathsPosFoldernamesMapper = {
+            expPath: natsorted(pos_foldernames) 
+            for expPath, pos_foldernames in expPathsPosFoldernamesMapper.items()
+        }
         return expPathsPosFoldernamesMapper
     
     def ok_cb(self):

--- a/cellacdc/cli.py
+++ b/cellacdc/cli.py
@@ -621,7 +621,6 @@ class SegmKernel(_WorkflowKernel):
                 lab_stack = core.post_process_segm(
                     lab_stack, **self.standard_postrocess_kwargs
                 )
-                printl(self.custom_postproc_features)
                 if self.custom_postproc_features:
                     lab_stack = features.custom_post_process_segm(
                         posData, self.custom_postproc_grouped_features, 


### PR DESCRIPTION
This PR implements a fix to correctly construct the dictionary mapping experiment folders to the list of Position folders to segment.