### PR TITLE
Correctly load cca table with NaNs

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -8644,7 +8644,13 @@ class editCcaTableWidget(QDialog):
             ccsValue = cca_df.at[ID, 'cell_cycle_stage']
             if ccsValue == 'S':
                 ccsValue = 'S/G2/M'
-            ccsComboBox.setCurrentText(ccsValue)
+            
+            try:
+                ccsComboBox.setCurrentText(ccsValue)
+            except Exception as err:
+                printl(ccsValue)
+                printl(cca_df)
+                raise err
             tableLayout.addWidget(ccsComboBox, row+1, col, alignment=AC)
             self.ccsComboBoxes.append(ccsComboBox)
             ccsComboBox.activated.connect(self.clearComboboxFocus)


### PR DESCRIPTION
When there are segmented cells without annotations, they appear in the table with NaNs --> this PR implements dropping of NaN while keeping the other annotations intact