### PR TITLE
Correctly load Images folder that do not have Position_ parent folder into segmentation module

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -18408,8 +18408,12 @@ class SelectFoldersToAnalyse(QBaseDialog):
             pos_foldernames = myutils.get_pos_foldernames(
                 selectedPath, check_if_is_sub_folder=True
             )
-            expPath = load.get_exp_path(selectedPath)
-            expPathsPosFoldernamesMapper[expPath].update(pos_foldernames)
+            if not pos_foldernames: 
+                images_path = myutils.get_images_folderpath(selectedPath)
+                expPathsPosFoldernamesMapper[selectedPath].add('')
+            else:
+                expPath = load.get_exp_path(selectedPath)
+                expPathsPosFoldernamesMapper[expPath].update(pos_foldernames)
         
         expPathsPosFoldernamesMapper = {
             expPath: natsorted(pos_foldernames) 

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -620,11 +620,27 @@ def get_pos_foldernames(exp_path, check_if_is_sub_folder=False):
             return [os.path.basename(exp_path)]
         elif is_images_folder:
             pos_path = os.path.dirname(exp_path)
-            return [os.path.basename(pos_path)]
+            if is_pos_folderpath(pos_path):
+                return [os.path.basename(pos_path)]
+            else:
+                return []
         else:
             return get_pos_foldernames(exp_path)
     return pos_foldernames
 
+def get_images_folderpath(folderpath):
+    if os.path.isfile(folderpath):
+        folderpath = os.path.dirname(folderpath)
+
+    if folderpath.endswith('Images'):
+        return folderpath
+    
+    images_folderpath = os.path.join(folderpath, 'Images')
+    if os.path.exists(images_folderpath):
+        return images_folderpath
+    
+    return ''
+    
 def getMostRecentPath():
     if os.path.exists(recentPaths_path):
         df = pd.read_csv(recentPaths_path, index_col='index')


### PR DESCRIPTION
When the Images folder is created by Cell-ACDC automatically when starting from image file, there is no parent Position_ folder. This PR fixes the loading of such a folder into the segmentation module