### PR TITLE
Ignore z-slice info missing in get_acdc_df_features

### DIFF
--- a/cellacdc/features.py
+++ b/cellacdc/features.py
@@ -106,7 +106,9 @@ def get_acdc_df_features(
             )
             
             # Get the z-slice if we have z-stacks
-            z = posData.zSliceSegmentation(filename, frame_i)
+            z = posData.zSliceSegmentation(
+                filename, frame_i, errors='ignore'
+            )
             
             # Get the background data
             bkgr_data = measurements.get_bkgr_data(

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -2938,14 +2938,20 @@ class loadData:
         metadataWin.deleteLater()
         return True
     
-    def zSliceSegmentation(self, filename, frame_i):
+    def zSliceSegmentation(self, filename, frame_i, errors='raise'):
         if self.SizeZ > 1:
             idx = (filename, frame_i)
-            if self.segmInfo_df.at[idx, 'resegmented_in_gui']:
-                col = 'z_slice_used_gui'
-            else:
-                col = 'z_slice_used_dataPrep'
-            z = self.segmInfo_df.at[idx, col]
+            try:
+                if self.segmInfo_df.at[idx, 'resegmented_in_gui']:
+                    col = 'z_slice_used_gui'
+                else:
+                    col = 'z_slice_used_dataPrep'
+                z = self.segmInfo_df.at[idx, col]
+            except Exception as err:
+                if errors == 'raise':
+                    raise err
+                else:
+                    return round(self.SizeZ / 2)
         else:
             z = None
         return z


### PR DESCRIPTION
When running the segmentation module and the z-slice for the features is missing, Cell-ACDC will now use the central z-slice for post-processing based on custom features. 