### PR TITLE
Allow possibility to select custom YeaZ_v2 models

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -258,7 +258,6 @@ try:
 except Exception as err:
     raise err
 
-
 try:
     # Import qrc_resources explicitly so that "from . import acdc_qrc_resources" imports 
     # the variable defined here. Use importlib in case qrc_resouces.py is in 

--- a/cellacdc/models/YeaZ_v2/__init__.py
+++ b/cellacdc/models/YeaZ_v2/__init__.py
@@ -1,3 +1,58 @@
-from cellacdc import myutils
+import os
+
+from cellacdc import myutils, load
 
 myutils.check_install_yeaz()
+
+custom_weights_json_filename = 'custom_weights_name_filepath.json'
+
+def add_model_filepath(name: str, filepath: os.PathLike):
+    _, model_folderpath = myutils.get_model_path(
+        'YeaZ_v2', create_temp_dir=False
+    )
+    custom_weights_json_file = os.path.join(
+        model_folderpath, custom_weights_json_filename
+    )
+    custom_weights_mapper = {}
+    if os.path.exists(custom_weights_json_file):
+        custom_weights_mapper = load.read_json(
+            custom_weights_json_file, 
+            desc='YeaZ_v2 custom weights filepath info'
+        )
+    
+    custom_weights_mapper[name] = filepath
+    load.write_json(custom_weights_mapper, custom_weights_json_file)
+    
+def load_models_filepath():
+    values = [
+        'Phase contrast',
+        'Bright-field',
+        'Fission yeast'
+    ]
+    mapper = {
+        'Phase contrast': 'weights_budding_PhC_multilab_0_1',
+        'Bright-field': 'weights_budding_BF_multilab_0_1',
+        'Fission yeast': 'weights_fission_multilab_0_2'
+    }
+    _, model_folderpath = myutils.get_model_path(
+        'YeaZ_v2', create_temp_dir=False
+    )
+    mapper = {
+        name: os.path.join(model_folderpath, filename) 
+        for name, filename in mapper.items()
+    }
+    
+    custom_weights_json_file = os.path.join(
+        model_folderpath, custom_weights_json_filename
+    )
+    if not os.path.exists(custom_weights_json_file):
+        return values, mapper
+    
+    custom_weights_mapper = load.read_json(
+        custom_weights_json_file, 
+        desc='YeaZ_v2 custom weights filepath info'
+    )
+    values.extend(custom_weights_mapper.keys())
+    mapper = {**mapper, **custom_weights_mapper}
+    
+    return values, mapper


### PR DESCRIPTION
This PR implements the possibility to select a custom YeaZ_v2 model. 

This is done by selecting the entry "Select custom model..." in the combobox. Then the user is asked to select the file path, insert a model name, and the information mapping model name to model filepath is saved as json in the acdc-appdata folder. 