### PR TITLE
Save and load selected measurements, closes #896

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -359,6 +359,9 @@ data_structure_docs_url = 'https://cell-acdc.readthedocs.io/en/latest/data-struc
 moth_bud_tot_selected_columns_filepath = os.path.join(
     settings_folderpath, 'mother_bud_total_columns_selection.json'
 )
+saved_measurements_selections_folderpath = os.path.join(
+    settings_folderpath, 'saved_measurements_selections'
+)
 
 # Use to get the acdc_output file name from `segm_filename` as 
 # `m = re.sub(segm_re_pattern, '_acdc_output', segm_filename)`

--- a/cellacdc/io.py
+++ b/cellacdc/io.py
@@ -9,6 +9,45 @@ import skimage.io
 
 from . import path, load, myutils, printl
 from . import moth_bud_tot_selected_columns_filepath
+from . import saved_measurements_selections_folderpath
+from . import config
+
+def get_saved_measurements_selections():
+    if not os.path.exists(saved_measurements_selections_folderpath):
+        return []
+    
+    return list(os.listdir(saved_measurements_selections_folderpath))
+
+def save_measurements_selections(
+        selected_measurements_filename, selected_measurements_dict
+    ):
+    os.makedirs(
+        saved_measurements_selections_folderpath, exist_ok=True
+    )
+    
+    configPars = config.ConfigParser()
+    for section, values in selected_measurements_dict.items():
+        configPars[section] = {}
+        for option, value in values.items():
+            configPars[section][option] = str(value)
+    
+    ini_filepath = os.path.join(
+        saved_measurements_selections_folderpath, selected_measurements_filename
+    )
+    with open(ini_filepath, 'w') as configfile:
+        configPars.write(configfile)
+    
+    return ini_filepath
+
+def read_measurements_selections(selected_measurements_filename):
+    ini_filepath = os.path.join(
+        saved_measurements_selections_folderpath, selected_measurements_filename
+    )
+    
+    cp = config.ConfigParser()
+    cp.read(ini_filepath)
+    
+    return dict(cp)
 
 def get_saved_moth_bud_tot_selections():
     if not os.path.exists(moth_bud_tot_selected_columns_filepath):

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -4332,7 +4332,6 @@ class CheckboxesGroupBox(QGroupBox):
         for checkBox in self.checkBoxes:
             checkBox.setChecked(checked)
             
-
 class _metricsQGBox(QGroupBox):
     sigDelClicked = Signal(str, object)
 


### PR DESCRIPTION
Save and load selected measurements, closes #896

Mail scroll area for set measurements dialogue to prevent too large window when many channels are present