### PR TITLE
Track sub-cell objs ignore intersect ID = 0

### DIFF
--- a/cellacdc/colors.py
+++ b/cellacdc/colors.py
@@ -197,7 +197,7 @@ def get_greedy_lut(lab, lut, ids=None):
     max_ID = max(ids, default=0)
     if max_ID + 1 > len(lut):
         # Repeat lut entries if not enough colors
-        lut = np.concat([lut]*((max_ID // len(lut))+1), axis=0)
+        lut = np.concatenate([lut]*((max_ID // len(lut))+1), axis=0)
     
     if lab.ndim == 3:
         lab = lab.max(axis=0)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -23457,7 +23457,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         selectOverlayLabels = widgets.QDialogListbox(
             'Select segmentation to overlay',
             'Select segmentation file to overlay:\n',
-            list(self.existingSegmEndNames), 
+            natsorted(self.existingSegmEndNames), 
             multiSelection=True, 
             parent=self
         )


### PR DESCRIPTION
When the "cells" are smaller than the "sub-cellular objects", the intersecting ID could be 0. However, this should be ignored and the positive ID should be considered for the intersection over area calculation. 