### PR TITLE
Clear manual background object item if ID not existing

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -15417,10 +15417,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         
         posData = self.data[self.pos_i]
         if ID not in posData.IDs:
-            self.manualTrackingButton = None
+            self.manualBackgroundObj = None
             self.manualBackgroundToolbar.showWarning(
                 f'The ID {ID} does not exist'
             )
+            self.manualBackgroundObjItem.clear()
             return
         
         ID_idx = posData.IDs_idxs[ID]


### PR DESCRIPTION
Clear the manual background object item if the ID does not exist

This can happen, for example, when moving to a Position that does not have the requested ID