### PR TITLE
Correct site-packages path for Google Colab

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -152,7 +152,7 @@ except Exception as e:
 
 import site
 sitepackages = site.getsitepackages()
-site_packages = [p for p in sitepackages if p.endswith('site-packages')][0]
+site_packages = [p for p in sitepackages if p.endswith('-packages')][0]
 
 cellacdc_path = os.path.dirname(os.path.abspath(__file__))
 cellacdc_installation_path = os.path.dirname(cellacdc_path)


### PR DESCRIPTION
When installing `cellacdc` in Colab environment the site packages is called `dist-packages` and not `site-packages`. This PR implements the fix where site packages is checked with `endswith('-packages')` instead of `endswith('site-packages')