### PR TITLE
fix: add pandas 3.0 compatibility by disabling strict string dtype

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -193,6 +193,11 @@ if os.path.exists(old_temp_path):
         print('^'*60)
 
 import pandas as pd
+# Disable pandas 3.0 strict string dtype to maintain backward compatibility
+# with code that assigns non-string values to DataFrames
+if hasattr(pd.options, 'future') and hasattr(pd.options.future, 'infer_string'):
+    pd.options.future.infer_string = False
+
 settings_csv_path = os.path.join(settings_folderpath, 'settings.csv')
 if not os.path.exists(settings_csv_path):
     df_settings = pd.DataFrame(


### PR DESCRIPTION
Pandas 3.0 uses strict string dtype by default, which raises TypeError when assigning non-string values (int, tuple, etc.) to string columns. This breaks many places in the codebase that rely on the old permissive object dtype behavior.

Setting `pd.options.future.infer_string = False` globally restores the pandas 2.x behavior where string columns use object dtype.