### PR TITLE
Add support for 3D tracking in Trackastra tracker

### DIFF
--- a/cellacdc/test_tracker.py
+++ b/cellacdc/test_tracker.py
@@ -21,10 +21,10 @@ from cellacdc._run import _setup_app
 app, splashScreen = _setup_app(splashscreen=True)  
 splashScreen.close()
 
-channel_name = 'Autofluorescence'
+channel_name = 'SiR_Hoechst'
 end_filename_segm = 'segm' # 'segm_test'
 START_FRAME = 0 
-STOP_FRAME = 400
+STOP_FRAME = 10
 # PLOT_FRAME = 499
 SAVE = False
 REAL_TIME_TRACKER = False
@@ -123,7 +123,8 @@ tracked_stack = core.tracker_track(
     logger_func=print
 )
 
-posData.fromTrackerToAcdcDf(tracker, tracked_stack, save=True)
+if hasattr(posData, 'acdc_output_csv_path'):
+    posData.fromTrackerToAcdcDf(tracker, tracked_stack, save=True)
 
 first_untracked_lab = lab_stack[0]
 uniqueID = max(np.max(lab_stack), np.max(tracked_stack)) + 1

--- a/cellacdc/trackers/Trackastra/Trackastra_tracker.py
+++ b/cellacdc/trackers/Trackastra/Trackastra_tracker.py
@@ -85,14 +85,11 @@ class tracker:
             in the `self.cca_dfs` list (one DataFrame with index `Cell_ID` per 
             frame). When used through Cell-ACDC, this list will be saved 
             to the acdc_output CSV file. 
-        """        
-        
-        if segm_video.ndim == 4:
-            raise TypeError('4D tracking not supported by Trackastra yet.')
-        
+        """                
         out = self.model.track(
             video_grayscale, segm_video, mode=linking_mode
         )
+        
         try:
             df_ctc, tracked_video = graph_to_ctc(out, segm_video)
         except Exception as e:


### PR DESCRIPTION
Add support for 3D tracking in Trackastra tracker. 

Note: the only pre-trained model that supports 3D tracking is `ctc`