### PR TITLE
feat: add functionality to reset lin tree when seg and tracking is changed

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -22366,7 +22366,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
     
     def resetLin_tree_future(self):
         if self.lineage_tree is not None:
-            printl("WARNING: resetting lineage tree future frames in the lineage_tree object is not implemented yet",
+            self.logger.info("WARNING: resetting lineage tree future frames in the lineage_tree object is not implemented yet",
                    "This is only for acdc_df dataframes")
         posData = self.data[self.pos_i]
         frame_i = posData.frame_i
@@ -26466,7 +26466,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         if self.isSnapshot:
             return True
 
-        printl("checking cca warning...")
         posData = self.data[self.pos_i]
         acdc_df = posData.allData_li[posData.frame_i]['acdc_df']
                 
@@ -26474,7 +26473,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
             if update_images:
                 self.updateAllImages()
             
-            printl("acdc_df is None and lineage_tree is None")
             return True
         cell_cycle_stage_present = (
             acdc_df is not None and 'cell_cycle_stage' in acdc_df.columns
@@ -26485,7 +26483,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         if not cell_cycle_stage_present and not lineage_tree_present:
             if update_images:
                 self.updateAllImages()
-            printl("no cca or lineage tree columns present")
             return True
             
         action = self.warnEditingWithAnnotActions.get(editTxt, None)


### PR DESCRIPTION
- add functionality to reset lin tree when edits are made in segmentation and tracking (based on cca reset in "warnEditingWithCca_df" function
- does not touch lineage tree outside of acdc_df since these should only be present when in lineage tree mode 