### PR TITLE
Fix for calculate metrics from utility

### DIFF
--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -100,6 +100,9 @@ class workerLogger:
 
     def warning(self, message):
         self.log(message, level='WARNING')
+    
+    def exception(self, message):
+        self.log(message, level='EXCEPTION')
 
 class signals(QObject):
     progress = Signal(str, object)


### PR DESCRIPTION
This PR adds the `exception` method to `workers.workerLogger` to maintain compatibility with cli logger