### PR TITLE
Fix for workerProgress method of compute measurements utility

### DIFF
--- a/cellacdc/utils/compute.py
+++ b/cellacdc/utils/compute.py
@@ -499,4 +499,6 @@ class computeMeasurmentsUtilWin(NewThreadMultipleExpBaseUtil):
     def workerProgress(self, text, loggerLevel='INFO'):
         if self.progressWin is not None:
             self.progressWin.logConsole.append(text)
+        if loggerLevel.upper() == 'EXCEPTION':
+            loggerLevel = 'ERROR'
         self.logger.log(getattr(logging, loggerLevel.upper()), text)


### PR DESCRIPTION
Correctly get the level of logging in workerProgress method of compute measurements utility class