### PR TITLE
Fix for when using Control + left click on mac for deleting object

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -14508,7 +14508,14 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements):
         delObjKeySequenceText = widgets.macShortcutToWindows(
             delObjKeySequence.toString()
         )
+        keySequenceText = widgets.macShortcutToWindows(keySequenceText)
 
+        # printl(
+        #     delObjKeySequence.toString(), 
+        #     keySequenceText, 
+        #     delObjKeySequenceText
+        # )
+        
         if keySequenceText == delObjKeySequenceText:
             self.delObjToolAction.setChecked(True)
     


### PR DESCRIPTION
Fix for when using Control + left click on mac for deleting object

On Mac, when using Control + left click, the left click is changed to a right click. If the delete object action is expected with left click, the right click must be changed to a left click. This PR fixes this by forcing a left click