### PR TITLE
Update workflows to Node 24 and remove git dependencies

### DIFF
--- a/.github/workflows/build-macos_pyqt5.yml
+++ b/.github/workflows/build-macos_pyqt5.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build-macos_pyqt6.yml
+++ b/.github/workflows/build-macos_pyqt6.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build-ubuntu_pyqt5.yml
+++ b/.github/workflows/build-ubuntu_pyqt5.yml
@@ -21,9 +21,9 @@ jobs:
       DISPLAY: ':99.0'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: setup ubuntu-latest

--- a/.github/workflows/build-windows_pyqt5.yml
+++ b/.github/workflows/build-windows_pyqt5.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/build-windows_pyqt6.yml
+++ b/.github/workflows/build-windows_pyqt6.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,21 +125,6 @@ deepsea = [
     "munkres",
 ]
 
-sam = [
-    "torch",
-    "segment_anything @ git+https://github.com/facebookresearch/segment-anything.git",
-]
-
-sam2 = [
-    "torch",
-    "sam-2 @ git+https://github.com/facebookresearch/sam2.git",
-]
-
-cellsam = [
-    "torch",
-    "cellSAM @ git+https://github.com/vanvalenlab/cellSAM.git",
-]
-
 all = [
     "PyQt6",
     "torchvision",


### PR DESCRIPTION
This PR updates the GitHub workflows to use Node24 and removes git+ dependencies in pyproject.toml file since this is not allowed for upload to PyPi