### PR TITLE
Copiable commands in messageBox

### DIFF
--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -4111,7 +4111,7 @@ def _warn_install_gpu(model_name, ask_installs, qparent=None):
         Check out these instructions {cellpose_href}, and {torch_href}.<br>
         First, uninstall the CPU version of PyTorch with the following command:
         <copiable>{pip_prefix} uninstall torch</copiable>
-        <br>Then, install the CUDA version required by your GPU with the follwing 
+        <br>Then, install the CUDA version required by your GPU with the following 
         command (in this case 12.8):
         <copiable>{pip_prefix} torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128</copiable>
         <br>

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -4109,19 +4109,18 @@ def _warn_install_gpu(model_name, ask_installs, qparent=None):
     pip_prefix = pip_prefix.replace('install -y', 'uninstall')
     txt_cuda = html_utils.paragraph(f"""
         Check out these instructions {cellpose_href}, and {torch_href}.<br>
-        First, uninstall the CPU version of PyTorch with the following command:<br><br>
-        <code>{pip_prefix} uninstall torch</code>.<br><br>
-        Then, install the CUDA version required by your GPU with the follwing 
-        command (in this case 12.8):<br><br>
-        <code>{pip_prefix} torch torchvision torchaudio --index-url 
-        https://download.pytorch.org/whl/cu128</code>
+        First, uninstall the CPU version of PyTorch with the following command:
+        <copiable>{pip_prefix} uninstall torch</copiable>
+        <br>Then, install the CUDA version required by your GPU with the follwing 
+        command (in this case 12.8):
+        <copiable>{pip_prefix} torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128</copiable>
         <br>
         """)
     
     add_info = html_utils.to_admonition(
         f"""
         Pleae use the following table to find the correct link for the command.
-        You can check the CUDA  <br> version installed on your system with the
+        You can check the highest CUDA  <br> version supported on your system with the
         command <code>nvidia-smi</code> in the terminal.<br>
 
         {html_utils.table_style_header}

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2514,9 +2514,20 @@ class myMessageBox(_base_widgets.QBaseDialog):
     def splitLatexBlocks(self, text):
         texts = re.split(r"(<latex.*?>.+?)</latex>", text)
         return texts        
+    
+    def splitCopiableBlocks(self, texts: list[str] | tuple[str]):
+        if isinstance(texts, str):
+            texts = (texts,)
+        
+        texts_out = []
+        for text in texts:
+            texts_out.extend(re.split(r"(<copiable>.+?)</copiable>", text))
+        return texts_out  
 
     def addText(self, text):
         texts = self.splitLatexBlocks(text)
+        texts = self.splitCopiableBlocks(texts)
+        
         labelsWidget = LabelsWidget(texts, wrapText=self.wrapText)
         self.labelsWidgets.append(labelsWidget)
         self.labels.extend(labelsWidget.labels)
@@ -2755,6 +2766,9 @@ class myMessageBox(_base_widgets.QBaseDialog):
             factor = np.ceil(textWidth/screenWidth)
             lineLength = int(labelWidget.nCharsLongestLine/factor)
             for label in labelWidget.labels:
+                if isinstance(label, widgets.CopiableCommandWidget):
+                    continue
+                
                 text = label.text()
                 chunks = textwrap.wrap(text, lineLength)
                 text = '<br>'.join(chunks)
@@ -7728,6 +7742,9 @@ class CopiableCommandWidget(QGroupBox):
         
         self.setLayout(layout)        
     
+    def setWordWrap(self, wordWrap):
+        self.label.setWordWrap(wordWrap)
+    
     def copyToClipboard(self):
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
@@ -7746,8 +7763,13 @@ class CopiableCommandWidget(QGroupBox):
     
     def command(self):
         return self._command
-        
-
+    
+    def text(self):
+        return self.label.text()
+    
+    def setTextInteractionFlags(self, flags):
+        self.label.setTextInteractionFlags(flags)
+    
 def PostProcessSegmWidget(
         minimum, maximum, value, useSliders, isFloat=False, normalize=False,
         label=None
@@ -9750,6 +9772,7 @@ class LabelsWidget(QWidget):
         for t, text in enumerate(texts):
             if not text:
                 continue
+
             if text.startswith('<latex>'):
                 layout.addSpacing(10)
                 label = LatexLabel(text)
@@ -9761,6 +9784,13 @@ class LabelsWidget(QWidget):
                         layout.addSpacing(10)
                 except IndexError:
                     layout.addSpacing(10)
+            elif text.startswith('<copiable>'):
+                text = (
+                    text.lstrip('<copiable>')
+                    .rstrip('</copiable>')
+                )
+                label = CopiableCommandWidget(command=text, parent=self)
+                layout.addWidget(label)
             else:
                 label = QLabel(text)
                 label.setWordWrap(wrapText)
@@ -9798,7 +9828,7 @@ class LabelsWidget(QWidget):
         
         fixedTexts = []
         for text in texts:
-            if text.startswith('<latex>'):
+            if text.startswith('<latex>') or text.startswith('<copiable>'):
                 fixedTexts.append(text)
                 continue
             

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, deque
-from typing import Dict, List, Union, Iterable
+from typing import Dict, List, Union, Iterable, Sequence
 import os
 import sys
 import operator
@@ -2515,7 +2515,7 @@ class myMessageBox(_base_widgets.QBaseDialog):
         texts = re.split(r"(<latex.*?>.+?)</latex>", text)
         return texts        
     
-    def splitCopiableBlocks(self, texts: list[str] | tuple[str]):
+    def splitCopiableBlocks(self, texts: Sequence[str] | str):
         if isinstance(texts, str):
             texts = (texts,)
         
@@ -9786,8 +9786,8 @@ class LabelsWidget(QWidget):
                     layout.addSpacing(10)
             elif text.startswith('<copiable>'):
                 text = (
-                    text.lstrip('<copiable>')
-                    .rstrip('</copiable>')
+                    text.removeprefix('<copiable>')
+                    .removeprefix('</copiable>')
                 )
                 label = CopiableCommandWidget(command=text, parent=self)
                 layout.addWidget(label)
@@ -9804,7 +9804,7 @@ class LabelsWidget(QWidget):
             
             self.labels.append(label)
         
-        self.nCharsLongestLine = max(self.textLengths)
+        self.nCharsLongestLine = max(self.textLengths, default=1)
         
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2766,7 +2766,7 @@ class myMessageBox(_base_widgets.QBaseDialog):
             factor = np.ceil(textWidth/screenWidth)
             lineLength = int(labelWidget.nCharsLongestLine/factor)
             for label in labelWidget.labels:
-                if isinstance(label, widgets.CopiableCommandWidget):
+                if isinstance(label, CopiableCommandWidget):
                     continue
                 
                 text = label.text()


### PR DESCRIPTION
When setting the `message` string of `widgets.myMessageBox` with the tag `<copiable>copiable command</copiable>`, the text "copiable command" is added with the `widgets.CopiableCommandWidget`, making it easier to copy the command. 

See #1075

Test with this code 

```python
from cellacdc._run import _setup_app
from cellacdc import myutils

app, splashScreen = _setup_app(splashscreen=True)  
splashScreen.close()

myutils._warn_install_gpu('cellpose_v4', ('cuda',))
```