### PR TITLE
Crash during segmentation saving

### DIFF
--- a/cellacdc/_run.py
+++ b/cellacdc/_run.py
@@ -90,7 +90,7 @@ def _install_tables(parent_software='Cell-ACDC'):
                     )
                     print('-'*100)
                 
-                import pdb; pdb.set_trace()
+                # import pdb; pdb.set_trace()
                 try:
                     subprocess.check_call(alt_cmd_args2, shell=alt_shell)
                     break

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6157,6 +6157,17 @@ class saveDataWorker(QObject):
     
     def saveSegmData(self, posData, end_i, saved_segm_data):
         self.progress.emit(f'Saving segmentation data for {posData.relPath}...')
+        
+        
+        # extend saved_segm_data if needed
+        if posData.SizeT > 1:
+            missing_frames_number = end_i + 1 - len(saved_segm_data)
+            saved_segm_data = np.concatenate(
+                (saved_segm_data, np.zeros((missing_frames_number, *saved_segm_data.shape[1:]), dtype=saved_segm_data.dtype)),
+            )
+
+        
+        import pdb; pdb.set_trace()
         for frame_i, data_dict in enumerate(posData.allData_li[:end_i+1]):
             if self.saveWin.aborted:
                 self.finished.emit()

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6167,7 +6167,6 @@ class saveDataWorker(QObject):
             )
 
         
-        import pdb; pdb.set_trace()
         for frame_i, data_dict in enumerate(posData.allData_li[:end_i+1]):
             if self.saveWin.aborted:
                 self.finished.emit()

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6162,9 +6162,16 @@ class saveDataWorker(QObject):
         # extend saved_segm_data if needed
         if posData.SizeT > 1:
             missing_frames_number = end_i + 1 - len(saved_segm_data)
-            saved_segm_data = np.concatenate(
-                (saved_segm_data, np.zeros((missing_frames_number, *saved_segm_data.shape[1:]), dtype=saved_segm_data.dtype)),
-            )
+            if missing_frames_number > 0:
+                saved_segm_data = np.concatenate(
+                    (
+                        saved_segm_data,
+                        np.zeros(
+                            (missing_frames_number, *saved_segm_data.shape[1:]),
+                            dtype=saved_segm_data.dtype
+                        )
+                    ),
+                )
 
         
         for frame_i, data_dict in enumerate(posData.allData_li[:end_i+1]):


### PR DESCRIPTION
Fixes #1078

The problem was that `posData.segm_data` was too short since in the segmentation module, not all frames were segmented. We now extend `saved_segm_data` before saving with empty arrays.