### PR TITLE
Ask for channel name when opening an image not in Images folder

### DIFF
--- a/cellacdc/acdc_regex.py
+++ b/cellacdc/acdc_regex.py
@@ -31,6 +31,9 @@ def is_alphanumeric_filename(text, allow_space=True):
     is_single_or_no_dot = len(re.findall(r'\.', text)) <= 1
     return bool(re.match(pattern, text)) and is_single_or_no_dot
 
+def get_non_alphanumeric_characters(text):
+    return re.findall(r'[^\w\-.]', '_', text)
+    
 if __name__ == '__main__':
     import re
     s = '0.5, 2.5, nan, NaN'

--- a/cellacdc/acdc_regex.py
+++ b/cellacdc/acdc_regex.py
@@ -32,7 +32,7 @@ def is_alphanumeric_filename(text, allow_space=True):
     return bool(re.match(pattern, text)) and is_single_or_no_dot
 
 def get_non_alphanumeric_characters(text):
-    return re.findall(r'[^\w\-.]', '_', text)
+    return re.findall(r'[^\w\-.]', text)
     
 if __name__ == '__main__':
     import re

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -1621,7 +1621,7 @@ class filenameDialog(QDialog):
         if len(characters) > 1:
             statement = 'are <b>not valid</b> chracters'
             
-        characters_str = ', '.join(characters)
+        characters_str = ''.join(characters)
         characters_str = html.escape(characters_str)
         warning_text = html_utils.span(f"""
             WARNING: "<code>{characters_str}</code>" {statement}.<br> 

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -88,7 +88,7 @@ from . import _core
 from . import _types
 from . import plot
 from . import urls
-from .acdc_regex import float_regex, is_alphanumeric_filename
+from .acdc_regex import float_regex, is_alphanumeric_filename, to_alphanumeric
 from . import _base_widgets
 from . import io
 from . import cca_functions
@@ -1520,8 +1520,9 @@ class filenameDialog(QDialog):
 
         basenameLabel = QLabel(basename)
 
-        self.lineEdit = QLineEdit()
+        self.lineEdit = widgets.alphaNumericLineEdit()
         self.lineEdit.setAlignment(Qt.AlignCenter)
+        defaultEntry = to_alphanumeric(defaultEntry)
         self.lineEdit.setText(defaultEntry)
 
         extLabel = QLabel(ext)
@@ -1535,8 +1536,10 @@ class filenameDialog(QDialog):
         entryLayout.addWidget(
             self.filenameLabel, 1, 1, 1, 3, alignment=Qt.AlignCenter
         )
-        entryLayout.setColumnStretch(0, 1)
-        entryLayout.setColumnStretch(4, 1)
+        # entryLayout.setColumnStretch(0, 1)
+        entryLayout.setColumnStretch(2, 1)
+        
+        self.warningInvalidCharLabel = QLabel()
 
         okButton = widgets.okPushButton('Ok')
         cancelButton = widgets.cancelPushButton('Cancel')
@@ -1564,6 +1567,9 @@ class filenameDialog(QDialog):
         cancelButton.clicked.connect(self.close)
         okButton.clicked.connect(self.ok_cb)
         self.lineEdit.textChanged.connect(self.updateFilename)
+        self.lineEdit.sigInvalidCharacterPressed.connect(
+            self.warnInvalidCharacterPressed
+        )
         
         self.existingNames = []
         if existingNames:
@@ -1573,6 +1579,8 @@ class filenameDialog(QDialog):
         layout.addWidget(hintLabel)
         layout.addSpacing(20)
         layout.addLayout(entryLayout)
+        layout.addSpacing(10)
+        layout.addWidget(self.warningInvalidCharLabel)
         layout.addStretch(1)
         layout.addSpacing(20)
         layout.addLayout(buttonsLayout)
@@ -1604,9 +1612,14 @@ class filenameDialog(QDialog):
         msg.information(self, 'Filename help', text)
 
     def _text(self):
-        _text = self.lineEdit.text().replace(' ', '_')
-        _text = self.lineEdit.text().replace('.', '_')
-        return _text
+        return self.lineEdit.text()
+    
+    def warnInvalidCharacterPressed(self, character: str):
+        warning_text = html_utils.span(f"""
+            <code>{character}</code> is <b>not a valid</b> character.<br> 
+            Valid characters are letters, numbers, underscore, and dash.
+        """)
+        self.warningInvalidCharLabel.setText(warning_text)
 
     def checkExistingNames(self):
         is_existing = (
@@ -1629,7 +1642,6 @@ class filenameDialog(QDialog):
         )
         return msg.clickedButton == yesButton
 
-
     def updateFilename(self, text):
         if not text:
             self.filenameLabel.setText(f'{self.basename}{self.ext}')
@@ -1642,6 +1654,8 @@ class filenameDialog(QDialog):
                     self.filenameLabel.setText(f'{self.basename}_{text}{self.ext}')
             else:
                 self.filenameLabel.setText(f'{text}{self.ext}')
+        
+        self.warningInvalidCharLabel.setText('')
 
     def checkEmptyText(self):
         if self.allowEmpty:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -44,6 +44,7 @@ import math
 import time
 import sympy as sp
 import json
+import html
 
 import pyqtgraph as pg
 pg.setConfigOption('imageAxisOrder', 'row-major')
@@ -1523,6 +1524,7 @@ class filenameDialog(QDialog):
         self.lineEdit = widgets.alphaNumericLineEdit()
         self.lineEdit.setAlignment(Qt.AlignCenter)
         defaultEntry = to_alphanumeric(defaultEntry)
+        defaultEntry = defaultEntry.replace('.', '_')
         self.lineEdit.setText(defaultEntry)
 
         extLabel = QLabel(ext)
@@ -1615,6 +1617,7 @@ class filenameDialog(QDialog):
         return self.lineEdit.text()
     
     def warnInvalidCharacterPressed(self, character: str):
+        character = html.escape(character)
         warning_text = html_utils.span(f"""
             <code>{character}</code> is <b>not a valid</b> character.<br> 
             Valid characters are letters, numbers, underscore, and dash.

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -1521,7 +1521,7 @@ class filenameDialog(QDialog):
 
         basenameLabel = QLabel(basename)
 
-        self.lineEdit = widgets.alphaNumericLineEdit()
+        self.lineEdit = widgets.alphaNumericLineEdit(onlyWarn=True)
         self.lineEdit.setAlignment(Qt.AlignCenter)
         defaultEntry = to_alphanumeric(defaultEntry)
         defaultEntry = defaultEntry.replace('.', '_')
@@ -1569,8 +1569,8 @@ class filenameDialog(QDialog):
         cancelButton.clicked.connect(self.close)
         okButton.clicked.connect(self.ok_cb)
         self.lineEdit.textChanged.connect(self.updateFilename)
-        self.lineEdit.sigInvalidCharacterPressed.connect(
-            self.warnInvalidCharacterPressed
+        self.lineEdit.sigInvalidCharactersEntered.connect(
+            self.warnInvalidCharactersEntered
         )
         
         self.existingNames = []
@@ -1616,12 +1616,20 @@ class filenameDialog(QDialog):
     def _text(self):
         return self.lineEdit.text()
     
-    def warnInvalidCharacterPressed(self, character: str):
-        character = html.escape(character)
+    def warnInvalidCharactersEntered(self, characters: set[str]):
+        statement = 'is <b>not a valid</b> character'
+        if len(characters) > 1:
+            statement = 'are <b>not valid</b> chracters'
+            
+        characters_str = ', '.join(characters)
+        characters_str = html.escape(characters_str)
         warning_text = html_utils.span(f"""
-            <code>{character}</code> is <b>not a valid</b> character.<br> 
-            Valid characters are letters, numbers, underscore, and dash.
+            WARNING: "<code>{characters_str}</code>" {statement}.<br> 
         """)
+        warning_text = (
+            f'{warning_text}'
+            '<i>Valid characters are letters, numbers, underscore, and dash.</i>'
+        )
         self.warningInvalidCharLabel.setText(warning_text)
 
     def checkExistingNames(self):
@@ -1646,6 +1654,9 @@ class filenameDialog(QDialog):
         return msg.clickedButton == yesButton
 
     def updateFilename(self, text):
+        if self.lineEdit.invalidCharacters():
+            return
+        
         if not text:
             self.filenameLabel.setText(f'{self.basename}{self.ext}')
         else:
@@ -1693,6 +1704,9 @@ class filenameDialog(QDialog):
         return False
     
     def ok_cb(self, checked=True):
+        if self.warningInvalidCharLabel.text():
+            return
+        
         valid = self.checkExistingNames()
         if not valid:
             return

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -1619,7 +1619,7 @@ class filenameDialog(QDialog):
     def warnInvalidCharactersEntered(self, characters: set[str]):
         statement = 'is <b>not a valid</b> character'
         if len(characters) > 1:
-            statement = 'are <b>not valid</b> chracters'
+            statement = 'are <b>not valid</b> characters'
             
         characters_str = ''.join(characters)
         characters_str = html.escape(characters_str)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -2469,8 +2469,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         menus = {}
         
         for toolName in allToolsList:
-            menutItemText = f'{toolName} tool'.replace('  ', ' ')
-            menus[toolName] = self.settingsMenu.addMenu(menutItemText)
+            menuItemText = f'{toolName} tool'.replace('  ', ' ')
+            menus[toolName] = self.settingsMenu.addMenu(menuItemText)
             
         self.keepToolActiveActions = dict()
         self.applyToolNewFrameActions = dict()
@@ -29410,9 +29410,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 return
         
         filename, ext = os.path.splitext(os.path.basename(file_path))
+        ext = ext.lower()
         dirpath = os.path.dirname(file_path)
         dirname = os.path.basename(dirpath)
-        filename, ext = os.path.splitext(os.path.basename(file_path))
         filename = filename.rstrip('_')
         channel_name = None
         do_copy = True
@@ -29486,7 +29486,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                         data.img_data, cv2.COLOR_RGBA2GRAY
                     )
                 data.img_data = skimage.img_as_ubyte(data.img_data)
-            tif_filename = new_filename.replace(ext, '.tif')
+            new_filename_no_ext, ext = os.path.splitext(new_filename)
+            tif_filename = f'{new_filename_no_ext}.tif'
             tif_path = os.path.join(exp_path, tif_filename)
             if data.img_data.ndim == 3:
                 SizeT = data.img_data.shape[0]

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29358,7 +29358,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             folder:
             <copiable>{images_path}</copiable>
             <br>
-            How do you want to proceed?
         """)
         
         if ext == '.tif' or ext == '.npz':

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -240,7 +240,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.original_df_lin_tree = None
         self.original_df_lin_tree_i = None
 
-    def setTooltips(self): #laoding tooltips for GUI from .\Cell_ACDC\docs\source\tooltips.rst
+    def setTooltips(self):
         tooltips = load.get_tooltips_from_docs()
 
         for key, tooltip in tooltips.items():
@@ -2469,7 +2469,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         menus = {}
         
         for toolName in allToolsList:
-            menus[toolName] = self.settingsMenu.addMenu(f'{toolName} tool')
+            menutItemText = f'{toolName} tool'.replace('  ', ' ')
+            menus[toolName] = self.settingsMenu.addMenu(menutItemText)
             
         self.keepToolActiveActions = dict()
         self.applyToolNewFrameActions = dict()
@@ -7116,11 +7117,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     self.assignBudMothButton.setChecked(False)
                     msg = widgets.myMessageBox()
                     txt = (
-                        f'You clicked FIRST on ID {budID} and then on {new_mothID}.\n'
+                        f'You clicked FIRST on ID {budID} and then on {new_mothID}.<br>'
                         f'For me this means that you want ID {budID} to be the '
-                        f'BUD of ID {new_mothID}.\n'
+                        f'BUD of ID {new_mothID}.<br>'
                         f'However <b>ID {budID} is bigger than {new_mothID}</b> '
-                        f'so maybe you shoul have clicked FIRST on {new_mothID}?\n\n'
+                        f'so maybe you should have clicked FIRST on {new_mothID}?<br><br>'
                         'What do you want me to do?'
                     )
                     txt = html_utils.paragraph(txt)
@@ -17238,11 +17239,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             **self.standardPostProcessKwargs,
             **self.customPostProcessFeatures
         }
-        posData.saveSegmHyperparams(
-            model_name, win.init_kwargs, win.model_kwargs,
-            post_process_params=post_process_params,
-            preproc_recipe=self.preproc_recipe
-        )
+        if askSegmParams:
+            posData.saveSegmHyperparams(
+                model_name, win.init_kwargs, win.model_kwargs,
+                post_process_params=post_process_params,
+                preproc_recipe=self.preproc_recipe
+            )
 
         if self.askRepeatSegment3D:
             self.segment3D = False
@@ -29339,9 +29341,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
 
         return True, win.entryText
     
-    def warnUserCreationImagesFolder(self, images_path):
+    def warnUserCreationImagesFolder(self, images_path, ext):
         msg = widgets.myMessageBox(wrapText=False)
-        txt = html_utils.paragraph(f"""
+        txt = (f"""
             Cell-ACDC requires a specific folder structure to load the data.<br><br>
             Specifically, it requires the <b>image(s) to be located in a
             folder called <code>Images</code></b>.<br><br>
@@ -29357,19 +29359,41 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             <br>
             How do you want to proceed?
         """)
-        copyButton = widgets.copyPushButton('Copy the image into the new folder')
-        moveButton = widgets.movePushButton('Move the image into the new folder')
-        _, copyButton, moveButton = msg.information(
-            self, 'Creating Images folder', txt, 
-            buttonsTexts=('Cancel', copyButton, moveButton)
-        )
-        if msg.cancel:
-            return False, None
+        if ext == '.tif' or ext == '.npz':
+            txt = f'{txt}How do you want to proceed?'
+        else:
+            txt = f'{txt}Do you want to proceed?'
+        txt = html_utils.paragraph(txt)
+        
+        
+        if ext == '.tif' or ext == '.npz':
+            copyButton = widgets.copyPushButton(
+                'Copy the image into the new folder'
+            )
+            moveButton = widgets.movePushButton(
+                'Move the image into the new folder'
+            )
+            _, copyButton, moveButton = msg.information(
+                self, 'Creating Images folder', txt, 
+                buttonsTexts=('Cancel', copyButton, moveButton)
+            )
+            if msg.cancel:
+                return False, None
 
-        if msg.clickedButton == copyButton:
+            if msg.clickedButton == copyButton:
+                return True, True
+            elif msg.clickedButton == moveButton:
+                return True, False
+        
+        else:
+            msg.information(
+                self, 'Creating Images folder', txt, 
+                buttonsTexts=('Cancel', 'Yes, proceed')
+            )
+            if msg.cancel:
+                return False, None
+            
             return True, True
-        elif msg.clickedButton == moveButton:
-            return True, False
 
     @exception_handler
     def _openFile(self, file_path=None):
@@ -29384,6 +29408,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 ";;All Files (*)")[0]
             if not file_path:
                 return
+        
+        filename, ext = os.path.splitext(os.path.basename(file_path))
         dirpath = os.path.dirname(file_path)
         dirname = os.path.basename(dirpath)
         filename, ext = os.path.splitext(os.path.basename(file_path))
@@ -29394,7 +29420,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
             acdc_folder = f'{timestamp}_acdc'
             exp_path = os.path.join(dirpath, acdc_folder, 'Images')
-            proceed, do_copy = self.warnUserCreationImagesFolder(exp_path)
+            proceed, do_copy = self.warnUserCreationImagesFolder(exp_path, ext)
             if not proceed:
                 self.logger.info('Loading image file cancelled.')
                 return

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29305,24 +29305,33 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.updateAllImages()
         self.logger.info('Annotations correctly recovered.')
 
-    def askUserChannelName(self, filename_no_ext):
+    def askUserChannelName(self, filename_no_ext, ext):
         help_txt = html_utils.paragraph(f"""
-            Cell-ACDC requires that every TIFF file has a basename and some 
+            Cell-ACDC requires that every image file has a basename and some 
             additional text, typically the channel name.<br><br>
             The basename will be common to all created files, while the additional text is used to identify the image files.
         """)
 
+        basename = filename_no_ext
+        underscore_splits = filename_no_ext.split('_')
+        if len(underscore_splits) > 1:
+            channel_name = underscore_splits[-1]
+            basename = '_'.join(underscore_splits[:-1])
+        else:
+            channel_name = 'channel_1'
+        
         txt = html_utils.paragraph(f"""
             Provide some text (e.g., the channel name) to append at the end of the image file.
         """)
         win = apps.filenameDialog(
-            basename=filename_no_ext,
+            basename=basename,
+            ext=ext,
             hintText=txt,
-            defaultEntry='channel_1',
+            defaultEntry=channel_name,
             helpText=help_txt, 
             allowEmpty=False,
             parent=self,
-            title='Save not whitelisted segmentation data',
+            title='Provide channel name for image file',
         )
         win.exec_()
         if win.cancel:
@@ -29378,6 +29387,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         dirpath = os.path.dirname(file_path)
         dirname = os.path.basename(dirpath)
         filename, ext = os.path.splitext(os.path.basename(file_path))
+        filename = filename.rstrip('_')
         channel_name = None
         do_copy = True
         if dirname != 'Images':
@@ -29389,7 +29399,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 self.logger.info('Loading image file cancelled.')
                 return
             
-            proceed, channel_name = self.askUserChannelName(filename)
+            proceed, channel_name = self.askUserChannelName(
+                filename, ext
+            )
             if not proceed:
                 self.logger.info('Loading image file cancelled.')
                 return
@@ -29399,6 +29411,13 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             exp_path = dirpath
 
         if channel_name is not None:
+            # Check if user wants to use the existing channel name
+            underscore_splits = filename.split('_')
+            if len(underscore_splits) > 1:
+                default_ch_name = underscore_splits[-1]
+                if channel_name == default_ch_name:
+                    filename = '_'.join(underscore_splits[:-1])
+                    
             basename = f'{filename}_'
             new_filename = f'{filename}_{channel_name}{ext}'
             df_metadata = pd.DataFrame({
@@ -29413,17 +29432,22 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         else:
             new_filename = f'{filename}{ext}'
         
+        if do_copy:
+            action_text = 'Copying'
+        else:
+            action_text = 'Moving'
+        
         if ext == '.tif' or ext == '.npz':
             new_filepath = os.path.join(exp_path, new_filename)
             if not os.path.exists(new_filepath):
-                self.logger.info('Copying file to Images folder...')
+                self.logger.info(f'{action_text} file to Images folder...')
                 if do_copy:
                     shutil.copy2(file_path, new_filepath)
                 else:
                     shutil.move(file_path, new_filepath)
             self._openFolder(exp_path=exp_path, imageFilePath=new_filepath)
         else:
-            self.logger.info('Copying file to .tif format...')
+            self.logger.info(f'{action_text} file to .tif format...')
             data = load.loadData(file_path, '', log_func=self.logger.info)
             data.loadImgData()
             img = data.img_data

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29327,7 +29327,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         """)
         win = apps.filenameDialog(
             basename=basename,
-            ext=ext,
+            ext='.tif',
             hintText=txt,
             defaultEntry=channel_name,
             helpText=help_txt, 

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29305,6 +29305,31 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.updateAllImages()
         self.logger.info('Annotations correctly recovered.')
 
+    def askUserChannelName(self, filename_no_ext):
+        help_txt = html_utils.paragraph(f"""
+            Cell-ACDC requires that every TIFF file has a basename and some 
+            additional text, typically the channel name.<br><br>
+            The basename will be common to all created files, while the additional text is used to identify the image files.
+        """)
+
+        txt = html_utils.paragraph(f"""
+            Provide some text (e.g., the channel name) to append at the end of the image file.
+        """)
+        win = apps.filenameDialog(
+            basename=filename_no_ext,
+            hintText=txt,
+            defaultEntry='channel_1',
+            helpText=help_txt, 
+            allowEmpty=False,
+            parent=self,
+            title='Save not whitelisted segmentation data',
+        )
+        win.exec_()
+        if win.cancel:
+            return False, ''
+
+        return True, win.entryText
+    
     def warnUserCreationImagesFolder(self, images_path):
         msg = widgets.myMessageBox(wrapText=False)
         txt = html_utils.paragraph(f"""
@@ -29313,18 +29338,19 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             folder called <code>Images</code></b>.<br><br>
             The <b>file format</b> of the images must be <b>TIFF</b> (.tif extension).<br><br>
             You can choose to let Cell-ACDC create the required data structure 
-            from your file, or you can stop the 
+            from your file,<br>
+            or you can stop the 
             process and manually place the image(s) into a folder called 
             <code>Images</code>.<br><br>
             If you choose to proceed, Cell-ACDC will create the following 
-            folder:<br><br>
-            <code>{images_path}</code>
-            <br><br>
+            folder:
+            <copiable>{images_path}</copiable>
+            <br>
             How do you want to proceed?
         """)
         copyButton = widgets.copyPushButton('Copy the image into the new folder')
         moveButton = widgets.movePushButton('Move the image into the new folder')
-        _, copyButton, moveButton = msg.warning(
+        _, copyButton, moveButton = msg.information(
             self, 'Creating Images folder', txt, 
             buttonsTexts=('Cancel', copyButton, moveButton)
         )
@@ -29351,6 +29377,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 return
         dirpath = os.path.dirname(file_path)
         dirname = os.path.basename(dirpath)
+        filename, ext = os.path.splitext(os.path.basename(file_path))
+        channel_name = None
         do_copy = True
         if dirname != 'Images':
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
@@ -29358,18 +29386,37 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             exp_path = os.path.join(dirpath, acdc_folder, 'Images')
             proceed, do_copy = self.warnUserCreationImagesFolder(exp_path)
             if not proceed:
-                self.logger.info('Loading image file aborted.')
+                self.logger.info('Loading image file cancelled.')
                 return
+            
+            proceed, channel_name = self.askUserChannelName(filename)
+            if not proceed:
+                self.logger.info('Loading image file cancelled.')
+                return
+            
             os.makedirs(exp_path, exist_ok=True)
         else:
             exp_path = dirpath
 
-        filename, ext = os.path.splitext(os.path.basename(file_path))
+        if channel_name is not None:
+            basename = f'{filename}_'
+            new_filename = f'{filename}_{channel_name}{ext}'
+            df_metadata = pd.DataFrame({
+                'Description': ['basename'],
+                'values': [basename]
+            })
+            metadata_csv_filename = f'{basename}metadata.csv'
+            metadata_csv_filepath = os.path.join(
+                exp_path, metadata_csv_filename
+            )
+            df_metadata.to_csv(metadata_csv_filepath, index=False)
+        else:
+            new_filename = f'{filename}{ext}'
+        
         if ext == '.tif' or ext == '.npz':
-            filename_ext = os.path.basename(file_path)
-            new_filepath = os.path.join(exp_path, filename_ext)
+            new_filepath = os.path.join(exp_path, new_filename)
             if not os.path.exists(new_filepath):
-                self.logger.info('Copying file to Image folder...')
+                self.logger.info('Copying file to Images folder...')
                 if do_copy:
                     shutil.copy2(file_path, new_filepath)
                 else:
@@ -29389,7 +29436,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                         data.img_data, cv2.COLOR_RGBA2GRAY
                     )
                 data.img_data = skimage.img_as_ubyte(data.img_data)
-            tif_path = os.path.join(exp_path, f'{filename}.tif')
+            tif_filename = new_filename.replace(ext, '.tif')
+            tif_path = os.path.join(exp_path, tif_filename)
             if data.img_data.ndim == 3:
                 SizeT = data.img_data.shape[0]
                 SizeZ = 1

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29327,7 +29327,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         """)
         win = apps.filenameDialog(
             basename=basename,
-            ext='.tif',
+            ext=ext,
             hintText=txt,
             defaultEntry=channel_name,
             helpText=help_txt, 
@@ -29347,7 +29347,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             Cell-ACDC requires a specific folder structure to load the data.<br><br>
             Specifically, it requires the <b>image(s) to be located in a
             folder called <code>Images</code></b>.<br><br>
-            The <b>file format</b> of the images must be <b>TIFF</b> (.tif extension).<br><br>
+            The <b>file format</b> of the images must be <b>TIFF or NPZ</b> 
+            (.tif or .npz extension).<br><br>
             You can choose to let Cell-ACDC create the required data structure 
             from your file,<br>
             or you can stop the 
@@ -29359,12 +29360,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             <br>
             How do you want to proceed?
         """)
+        
         if ext == '.tif' or ext == '.npz':
             txt = f'{txt}How do you want to proceed?'
         else:
             txt = f'{txt}Do you want to proceed?'
         txt = html_utils.paragraph(txt)
-        
         
         if ext == '.tif' or ext == '.npz':
             copyButton = widgets.copyPushButton(
@@ -29426,7 +29427,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 return
             
             proceed, channel_name = self.askUserChannelName(
-                filename, ext
+                filename, '.tif'
             )
             if not proceed:
                 self.logger.info('Loading image file cancelled.')

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2228,6 +2228,8 @@ class pgScatterSymbolsCombobox(QComboBox):
 
 
 class alphaNumericLineEdit(QLineEdit):
+    sigInvalidCharacterPressed = Signal(str)
+    
     def __init__(self, parent=None, additionalChars=''):
         super().__init__(parent)
 
@@ -2237,6 +2239,17 @@ class alphaNumericLineEdit(QLineEdit):
         self.setValidator(QRegularExpressionValidator(regExp))
 
         # self.setAlignment(Qt.AlignCenter)
+    
+    def keyPressEvent(self, event: QKeyEvent):
+        if not event.text():
+            return super().keyPressEvent(event)
+        
+        super().keyPressEvent(event)
+        
+        if event.text() in self.text():
+            return
+        
+        self.sigInvalidCharacterPressed.emit(event.text())
 
 class NumericCommaLineEdit(QLineEdit):
     def __init__(self, parent=None):
@@ -3807,10 +3820,10 @@ class selectStartStopFrames(QGroupBox):
         selectFramesLayout.addWidget(self.stopFrame_SB, 1, 1)
 
         self.warningLabel = QLabel()
-        palette = self.warningLabel.palette();
-        palette.setColor(self.warningLabel.backgroundRole(), Qt.red);
-        palette.setColor(self.warningLabel.foregroundRole(), Qt.red);
-        self.warningLabel.setPalette(palette);
+        palette = self.warningLabel.palette()
+        palette.setColor(self.warningLabel.backgroundRole(), Qt.red)
+        palette.setColor(self.warningLabel.foregroundRole(), Qt.red)
+        self.warningLabel.setPalette(palette)
         selectFramesLayout.addWidget(
             self.warningLabel, 2, 0, 1, 2, alignment=Qt.AlignCenter
         )

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2243,6 +2243,16 @@ class alphaNumericLineEdit(QLineEdit):
     def keyPressEvent(self, event: QKeyEvent):
         if not event.text():
             return super().keyPressEvent(event)
+
+        if event.modifiers() & (
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.AltModifier
+            | Qt.KeyboardModifier.MetaModifier
+        ):
+            return super().keyPressEvent(event)
+
+        if not event.text().isprintable():
+            return super().keyPressEvent(event)
         
         super().keyPressEvent(event)
         

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2229,16 +2229,28 @@ class pgScatterSymbolsCombobox(QComboBox):
 
 class alphaNumericLineEdit(QLineEdit):
     sigInvalidCharacterPressed = Signal(str)
+    sigInvalidCharactersEntered = Signal(object)
     
-    def __init__(self, parent=None, additionalChars=''):
+    def __init__(self, parent=None, additionalChars='', onlyWarn=False):
         super().__init__(parent)
-
         self.validPattern = fr'^[a-zA-Z0-9{additionalChars}_\-]+$'
+        self.invalidPattern = fr'[^a-zA-Z0-9{additionalChars}_\-]'
+        
+        if not onlyWarn:
+            regExp = QRegularExpression(self.validPattern)
+            self.setValidator(QRegularExpressionValidator(regExp))
+        else:
+            self.textChanged.connect(self.emitInvalidCharactersEntered)
 
-        regExp = QRegularExpression(self.validPattern)
-        self.setValidator(QRegularExpressionValidator(regExp))
-
-        # self.setAlignment(Qt.AlignCenter)
+    def emitInvalidCharactersEntered(self, text):
+        invalidCharacters = self.invalidCharacters()
+        if not invalidCharacters:
+            return
+        
+        self.sigInvalidCharactersEntered.emit(set(invalidCharacters))
+    
+    def invalidCharacters(self):
+        return re.findall(fr'{self.invalidPattern}', self.text())
     
     def keyPressEvent(self, event: QKeyEvent):
         if not event.text():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ dependencies = [
     "requests",
     "setuptools-scm",
     "matplotlib",
-    "sympy"
+    "sympy",
+    "imagecodecs"
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
When opening an image file that is not in the `Images` folder, Cell-ACDC needs to copy or move the file to a newly created `Images` folder. However, at this point, the basename would be the entire filename, which can cause problems downstream.

With this PR, Cell-ACDC will now ask the user to provide additional text to append to the image filename, e.g., the channel name. 

Then the basename can safely become the original filename and the new file will have the channel name appended as usual.

Additionally, add `imagecodecs` to dependencies to ensure compatibility with tiff files.