### PR TITLE
fix: Prevent Clear freehand ROI from being drawn on right-click

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -7175,6 +7175,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         # Draw clear region mouse release
         elif self.isMouseDragImg1 and self.drawClearRegionButton.isChecked():
+            self.isMouseDragImg1 = False
             self.freeRoiItem.closeCurve()
             self.clearObjsFreehandRegion()
         


### PR DESCRIPTION
I noticed a bug where when I would select "Clear freehand region" (with "Clear all touching objects" selected), and then "Merge IDs", and then proceed to merge two objects, the objects would be both merged and then deleted.

My understanding of the issue is that Clear freehand region is supposed to be a Left-click only tool, but was drawing its ROI on right click as well since `isMouseDragImg1` was not being reset to `False`. This PR fixes that.

May I further propose a refactor where each left-click tool has a function associated with it that performs its task? And then that way `gui_mouseReleaseEventImg1` function can handle the `isRightClickDragImg1` logic while the button functions only have to handle logic specific to their tools. If that makes sense to you all, I could give it a try when I next have the time.