### PR TITLE
fix: truncate lists properly

### DIFF
--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import ast
+import math
 
 import typing
 from typing import Literal, List, Callable, Tuple, Dict
@@ -272,14 +273,14 @@ def get_trimmed_list(li: list, max_num_digits=10):
     tom_num_digits = sum([len(str(val)) for val in li])
     avg_num_digits = tom_num_digits/len(li)
     max_num_vals = int(round(max_num_digits/avg_num_digits))
-    if tom_num_digits>max_num_digits:
-        li_str = li.copy()
-        del li_str[max_num_vals:-max_num_vals]
-        li_str.insert(max_num_vals, "...")
-        li_str = f"[{', '.join(map(str, li_str))}]"
-    else:
-        li_str = f"{[str(val) for val in li]}".replace('\'', '')
-    return li_str
+
+    if tom_num_digits > max_num_digits:
+        front_digits = math.ceil(max_num_vals / 2)
+        back_digits = max_num_vals // 2
+
+        li = li[:front_digits] + ['...'] + li[-back_digits:]
+
+    return  f"[{', '.join(map(str, li))}]"
 
 def get_trimmed_dict(di: dict, max_num_digits=10):
     di_str = di.copy()

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -277,7 +277,7 @@ def get_trimmed_list(li: list, max_num_digits=10):
         front_vals = ceil(max_num_vals / 2)
         back_vals = max_num_vals // 2
 
-        li = li[:front_vals] + ['...'] + li[-back_vals:]
+        li = li[:front_vals] + ['...'] + li[len(li) - back_vals:]
 
     return f"[{', '.join(map(str, li))}]"
 

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -275,10 +275,10 @@ def get_trimmed_list(li: list, max_num_digits=10):
     max_num_vals = int(round(max_num_digits/avg_num_digits))
 
     if tom_num_digits > max_num_digits:
-        front_digits = math.ceil(max_num_vals / 2)
-        back_digits = max_num_vals // 2
+        front_vals = math.ceil(max_num_vals / 2)
+        back_vals = max_num_vals // 2
 
-        li = li[:front_digits] + ['...'] + li[-back_digits:]
+        li = li[:front_vals] + ['...'] + li[-back_vals:]
 
     return f"[{', '.join(map(str, li))}]"
 

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -283,6 +283,9 @@ def get_trimmed_list(li: list, max_num_digits=10):
     if tom_num_digits > max_num_digits:
         front_vals = ceil(max_num_vals / 2)
         back_vals = max_num_vals // 2
+        
+        if front_vals + back_vals >= len(li):
+            return f"[{', '.join(map(str, li))}]"
 
         li = li[:front_vals] + ['...'] + li[len(li) - back_vals:]
 

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -1,7 +1,6 @@
 import os
 import re
 import ast
-import math
 
 import typing
 from typing import Literal, List, Callable, Tuple, Dict
@@ -275,7 +274,7 @@ def get_trimmed_list(li: list, max_num_digits=10):
     max_num_vals = int(round(max_num_digits/avg_num_digits))
 
     if tom_num_digits > max_num_digits:
-        front_vals = math.ceil(max_num_vals / 2)
+        front_vals = ceil(max_num_vals / 2)
         back_vals = max_num_vals // 2
 
         li = li[:front_vals] + ['...'] + li[-back_vals:]

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -269,7 +269,14 @@ class utilClass:
     pass
 
 def get_trimmed_list(li: list, max_num_digits=10):
+    if len(li) == 0:
+        return '[]'
+    
     tom_num_digits = sum([len(str(val)) for val in li])
+    
+    if tom_num_digits == 0:
+        return f"[{', '.join(map(str, li))}]"
+    
     avg_num_digits = tom_num_digits/len(li)
     max_num_vals = int(round(max_num_digits/avg_num_digits))
 

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -280,7 +280,7 @@ def get_trimmed_list(li: list, max_num_digits=10):
 
         li = li[:front_digits] + ['...'] + li[-back_digits:]
 
-    return  f"[{', '.join(map(str, li))}]"
+    return f"[{', '.join(map(str, li))}]"
 
 def get_trimmed_dict(di: dict, max_num_digits=10):
     di_str = di.copy()


### PR DESCRIPTION
I noticed that the "New IDs" list was showing things like "[1410, 1421, ..., 1422]" when the only new IDs were 1410, 1421, and 1422. The issue was that the items being deleted from the center of  the list was not being calculated correctly in `get_trimmed_list`.

I've simplified that function and fixed the bug.

This causes the above example to become "[1410, ..., 1422]".