### PR TITLE
Store data on current frame when using spinbox or dragging slider

### DIFF
--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -20445,6 +20445,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         if self.isSnapshot:
             self.PosScrollBarMoved(value)
         else:
+            mode = str(self.modeComboBox.currentText())
+            # Store data for current frame
+            if mode != 'Viewer':
+                self.store_data(debug=False)
             self.navigateScrollBarStartedMoving = True
             self.framesScrollBarMoved(value)
     
@@ -20507,6 +20511,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.framesScrollBarReleased()
 
     def framesScrollBarMoved(self, frame_n):
+        if self.navigateScrollBarStartedMoving:
+            mode = str(self.modeComboBox.currentText())
+            if mode != 'Viewer':
+                self.store_data(debug=False)
+                
         posData = self.data[self.pos_i]
         posData.frame_i = frame_n-1
         if posData.allData_li[posData.frame_i]['labels'] is None:

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -20451,10 +20451,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         if self.isSnapshot:
             self.PosScrollBarMoved(value)
         else:
-            mode = str(self.modeComboBox.currentText())
-            # Store data for current frame
-            if mode != 'Viewer':
-                self.store_data(debug=False)
             self.navigateScrollBarStartedMoving = True
             self.framesScrollBarMoved(value)
     
@@ -20512,9 +20508,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         elif action == SliderSingleStepSub:
             self.prev_cb()
         elif action == SliderPageStepAdd:
-            self.framesScrollBarReleased()
+            self.framesScrollBarReleased(do_store_data=True)
         elif action == SliderPageStepSub:
-            self.framesScrollBarReleased()
+            self.framesScrollBarReleased(do_store_data=True)
 
     def framesScrollBarMoved(self, frame_n):
         if self.navigateScrollBarStartedMoving:
@@ -20549,9 +20545,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.updateHighlightedAxis()
         self.navigateScrollBarStartedMoving = False
 
-    def framesScrollBarReleased(self):
-        self.navigateScrollBarStartedMoving = True
+    def framesScrollBarReleased(self, do_store_data=False):
         posData = self.data[self.pos_i]
+        if posData.frame_i == self.navigateScrollBar.sliderPosition()-1:
+            # Slider released without changing value --> do nothing
+            return
+        
+        mode = str(self.modeComboBox.currentText())
+        if mode != 'Viewer' and do_store_data:
+            self.store_data(debug=False)
+            
+        self.navigateScrollBarStartedMoving = True
         posData.frame_i = self.navigateScrollBar.sliderPosition()-1
         self.updateFramePosLabel()
         proceed_cca, never_visited = self.get_data()

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -3992,6 +3992,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.navSpinBox.editingFinished.connect(
             self.navigateSpinboxEditingFinished
         )
+        self.navSpinBox.sigUpClicked.connect(
+            self.navigateSpinboxEditingFinished
+        )
+        self.navSpinBox.sigDownClicked.connect(
+            self.navigateSpinboxEditingFinished
+        )
 
         self.lastTrackedFrameLabel = QLabel()
         self.lastTrackedFrameLabel.setFont(_font)


### PR DESCRIPTION
When dragging the frames scrollbar or changing frame through the frames spinbox, edits were lost because `store_data` was never called. 

This PR fixed that.