### PR TITLE
Use symbolic links instead of copying image data to Images folder

### DIFF
--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -807,3 +807,12 @@ single_pos_index_cols = (
     'experiment_folderpath', 
     'Position_n'
 )
+
+valid_image_data_ends = (
+    '_aligned.npz', 
+    '_aligned.h5', 
+    '.h5', 
+    '.tif', 
+    '.npz',
+    '_symlink.ini'
+)

--- a/cellacdc/__init__.py
+++ b/cellacdc/__init__.py
@@ -69,6 +69,9 @@ IMAGE_EXTENSIONS = (
 VIDEO_EXTENSIONS = (
     '.mp4', '.avi', '.mov', '.mkv', '.webm', '.flv',
 )
+ACDC_IMAGE_EXTENSIONS = (
+    *IMAGE_EXTENSIONS, '.h5', '.npy', '.npz'
+)
 
 def _warn_ask_install_package(
         commands: Iterable[str], note_txt='', caller='SpotMAX'

--- a/cellacdc/_main.py
+++ b/cellacdc/_main.py
@@ -435,12 +435,16 @@ class mainWin(QMainWindow):
         concatMenu.addAction(self.concatAcdcDfsAction)    
         if SPOTMAX_INSTALLED:
             concatMenu.addAction(self.concatSpotmaxDfsAction) 
+            
+        folderDataStructMenu = utilsMenu.addMenu(
+            'Folder structure'
+        )
+        folderDataStructMenu.addAction(self.batchConverterAction)
+        folderDataStructMenu.addAction(self.symLinkPosAction)
 
         dataPrepMenu = utilsMenu.addMenu(
             'Image and segmentation files preprocessing'
         )
-                 
-        dataPrepMenu.addAction(self.batchConverterAction)
         dataPrepMenu.addAction(self.repeatDataPrepAction)
         dataPrepMenu.addAction(self.alignAction)
         dataPrepMenu.addAction(self.resizeImagesAction)
@@ -787,6 +791,10 @@ class mainWin(QMainWindow):
         self.batchConverterAction = QAction(
             'Create required data structure from image files...'
         )
+        self.symLinkPosAction = QAction(
+            'Create new folders with symbolic link to existing Position folders...'
+        )
+        
         self.repeatDataPrepAction = QAction(
             'Re-apply data prep steps to selected channels...'
         )
@@ -902,11 +910,15 @@ class mainWin(QMainWindow):
         )        
         
         self.batchConverterAction.triggered.connect(
-                self.launchImageBatchConverter
-            )
+            self.launchImageBatchConverter
+        )
+        self.symLinkPosAction.triggered.connect(
+            self.launchSymLinkPosProcess
+        )
+        
         self.repeatDataPrepAction.triggered.connect(
-                self.launchRepeatDataPrep
-            )
+            self.launchRepeatDataPrep
+        )
         self.welcomeGuideAction.triggered.connect(self.launchWelcomeGuide)
         self.toSymDivAction.triggered.connect(self.launchToSymDicUtil)
         self.calcMetricsAcdcDf.triggered.connect(self.launchCalcMetricsUtil)
@@ -1757,9 +1769,16 @@ class mainWin(QMainWindow):
         self.batchConverterWin = utilsConvert.ImagesToPositions(parent=self)
         self.batchConverterWin.show()
     
+    def launchSymLinkPosProcess(self):
+        self.dataStructWin = dataStruct.CreateSymLinkToPosWin(
+            parent=self, version=self._version
+        )
+        self.dataStructWin.show()
+        self.dataStructWin.main()
+    
     def launchRepeatDataPrep(self):
-        self.batchConverterWin = utilsRepeat.repeatDataPrepWindow(parent=self)
-        self.batchConverterWin.show()
+        self.repeatDataPrepWin = utilsRepeat.repeatDataPrepWindow(parent=self)
+        self.repeatDataPrepWin.show()
 
     def launchDataStruct(self, checked=False):
         self.dataStructButton.setPalette(self.moduleLaunchedPalette)

--- a/cellacdc/_main.py
+++ b/cellacdc/_main.py
@@ -1796,6 +1796,15 @@ class mainWin(QMainWindow):
             """, 'important'
         )
         
+        symlink_info_admon = html_utils.to_admonition(
+            f"""
+            A symbolic link is a special type of file that acts as a pointer or alias, 
+            referring to another file by its path rather than its content.<br>
+            If you already created a Cell-ACDC compatible data structure and you just want to re-use the same Position folders,<br> 
+            you can create symbolic links to them.
+            """, 'note'
+        )
+        
         issues_href = f'<a href="{issues_url}">GitHub page</a>'
         txt = html_utils.paragraph(f"""
     To process microscopy files, Cell-ACDC uses the {bioio_href} library.<br><br>
@@ -1810,7 +1819,12 @@ class mainWin(QMainWindow):
     
     {conda_important_admon}<br>
     
-    Alternatively, if you <b>already pre-processed your microscopy files into .tif 
+    Alternatively, you can choose to create new Position folders with 
+    symbolic links to existing Position folders.<br>
+    
+    {symlink_info_admon}<br>
+    
+    Finally, if you <b>already pre-processed your microscopy files into .tif 
     files</b>,<br>
     you can choose to simply re-structure them into the Cell-ACDC compatible 
     format.<br><br>
@@ -1825,10 +1839,15 @@ class mainWin(QMainWindow):
         useBioFormatsButton = QPushButton(
             QIcon(':ome.svg'), ' Use BioIO ', msg
         )
+        symLinkToPosButton = QPushButton(
+            QIcon(':segment.svg'), 
+            'Create a symbolic link to existing Position(s) ', 
+            msg
+        )
         restructButton = QPushButton(
             QIcon(':folders.svg'), ' Re-structure image files ', msg
         )
-        buttons = [useBioFormatsButton, restructButton]
+        buttons = [useBioFormatsButton, symLinkToPosButton, restructButton]
         if is_mac:
             useFijiMacroButton = QPushButton(
                 QIcon(':fiji-logo.svg'), ' Use Fiji Macro ', msg
@@ -1869,7 +1888,15 @@ class mainWin(QMainWindow):
                     self.restoreDefaultButtons()
             elif useFijiMacro:
                 self.runFijiMacroWorkflow()
-        if msg.clickedButton == restructButton:
+        
+        if msg.clickedButton == symLinkToPosButton:
+            self.dataStructWin = dataStruct.CreateSymLinkToPosWin(
+                parent=self, version=self._version
+            )
+            self.dataStructWin.show()
+            self.dataStructWin.main()
+        
+        elif msg.clickedButton == restructButton:
             self.progressWin = apps.QDialogWorkerProgress(
                 title='Re-structure image files log', parent=self,
                 pbarDesc='Re-structuring image files running...'

--- a/cellacdc/_main.py
+++ b/cellacdc/_main.py
@@ -1914,6 +1914,7 @@ class mainWin(QMainWindow):
             )
             self.dataStructWin.show()
             self.dataStructWin.main()
+            self.restoreDefaultButtons()
         
         elif msg.clickedButton == restructButton:
             self.progressWin = apps.QDialogWorkerProgress(

--- a/cellacdc/acdc_bioio_bioformats/__init__.py
+++ b/cellacdc/acdc_bioio_bioformats/__init__.py
@@ -9,7 +9,7 @@ if conda_prefix is not None:
     else:
         os.environ["JAVA_HOME"] = conda_prefix
     
-    print('Setting JAVA_HOME:', os.environ["JAVA_HOME"])
+    # print('Setting JAVA_HOME:', os.environ["JAVA_HOME"])
 
 EXTENSION_PACKAGE_MAPPER = {
     '.czi': 'bioio-czi',

--- a/cellacdc/acdc_bioio_bioformats/_init_reader.py
+++ b/cellacdc/acdc_bioio_bioformats/_init_reader.py
@@ -4,23 +4,23 @@ import argparse
 
 ap = bioformats._utils.setup_argparser()
 
-try:
-    ap.add_argument(
-        '-f', 
-        '--filepath', 
-        required=True, 
-        type=str, 
-        metavar='FILEPATH',
-        help='Filepath of a raw microscopy file to test.'
-    )
+ap.add_argument(
+    '-f', 
+    '--filepath', 
+    required=True, 
+    type=str, 
+    metavar='FILEPATH',
+    help='Filepath of a raw microscopy file to test.'
+)
 
-    args = vars(ap.parse_args())
+args = vars(ap.parse_args())
+
+try:
+    
     raw_filepath = args['filepath']
 
     with bioformats.ImageReader(raw_filepath, qparent=None) as reader:
         print(reader)
 except Exception as err:
-    args = vars(ap.parse_args())
-    uuid4 = args['uuid']
-    
+    uuid4 = args['uuid4']
     bioformats._utils.dump_exception(err, uuid4)

--- a/cellacdc/acdc_bioio_bioformats/_read_metadata.py
+++ b/cellacdc/acdc_bioio_bioformats/_read_metadata.py
@@ -11,18 +11,18 @@ from cellacdc import acdc_bioio_bioformats as bioformats
 import argparse
 
 ap = bioformats._utils.setup_argparser()
+ap.add_argument(
+    '-f', 
+    '--filepath', 
+    required=True, 
+    type=str, 
+    metavar='FILEPATH',
+    help='Filepath of a raw microscopy file to test.'
+)
+
+args = vars(ap.parse_args())
 
 try:
-    ap.add_argument(
-        '-f', 
-        '--filepath', 
-        required=True, 
-        type=str, 
-        metavar='FILEPATH',
-        help='Filepath of a raw microscopy file to test.'
-    )
-
-    args = vars(ap.parse_args())
     raw_filepath = args['filepath']
 
     metadataXML = bioformats.get_omexml_metadata(raw_filepath)
@@ -39,7 +39,5 @@ try:
     )
     metadata.to_file(metadata_filepath)
 except Exception as err:
-    args = vars(ap.parse_args())
-    uuid4 = args['uuid']
-    
+    uuid4 = args['uuid4']
     bioformats._utils.dump_exception(err, uuid4)

--- a/cellacdc/acdc_bioio_bioformats/_read_sample_data.py
+++ b/cellacdc/acdc_bioio_bioformats/_read_sample_data.py
@@ -10,52 +10,52 @@ from cellacdc import acdc_bioio_bioformats as bioformats
 import argparse
 
 ap = bioformats._utils.setup_argparser()
+ap.add_argument(
+    '-f', 
+    '--filepath', 
+    required=True, 
+    type=str, 
+    metavar='FILEPATH',
+    help='Filepath of a raw microscopy file to test.'
+)
+
+ap.add_argument(
+    '-c', 
+    '--SizeC', 
+    required=True, 
+    type=int, 
+    metavar='SIZEC',
+    help='Number of channels in the microscopy file.'
+)
+
+ap.add_argument(
+    '-t', 
+    '--SizeT', 
+    required=True, 
+    type=int, 
+    metavar='SIZET',
+    help='Number of timepoints in the microscopy file.'
+)
+
+ap.add_argument(
+    '-z', 
+    '--SizeZ', 
+    required=True, 
+    type=int, 
+    metavar='SIZEZ',
+    help='Number of z-slices in a single z-stack.'
+)
+
+ap.add_argument(
+    '-a', 
+    '--all', 
+    action='store_true', 
+    help='Whether to read entire position into RAM or not.'
+)
+
+args = vars(ap.parse_args())
 
 try:
-    ap.add_argument(
-        '-f', 
-        '--filepath', 
-        required=True, 
-        type=str, 
-        metavar='FILEPATH',
-        help='Filepath of a raw microscopy file to test.'
-    )
-
-    ap.add_argument(
-        '-c', 
-        '--SizeC', 
-        required=True, 
-        type=int, 
-        metavar='SIZEC',
-        help='Number of channels in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-t', 
-        '--SizeT', 
-        required=True, 
-        type=int, 
-        metavar='SIZET',
-        help='Number of timepoints in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-z', 
-        '--SizeZ', 
-        required=True, 
-        type=int, 
-        metavar='SIZEZ',
-        help='Number of z-slices in a single z-stack.'
-    )
-    
-    ap.add_argument(
-        '-a', 
-        '--all', 
-        action='store_true', 
-        help='Whether to read entire position into RAM or not.'
-    )
-
-    args = vars(ap.parse_args())
     raw_filepath = args['filepath']
 
     SizeC = args['SizeC']
@@ -101,7 +101,5 @@ try:
         np.save(filepath, channel_data)
 
 except Exception as err:
-    args = vars(ap.parse_args())
-    uuid4 = args['uuid']
-    
+    uuid4 = args['uuid4']
     bioformats._utils.dump_exception(err, uuid4)

--- a/cellacdc/acdc_bioio_bioformats/_save_data.py
+++ b/cellacdc/acdc_bioio_bioformats/_save_data.py
@@ -135,6 +135,13 @@ try:
         action='store_true', 
         help='Whether to read entire position into RAM or not.'
     )
+    
+    ap.add_argument(
+        '-u', 
+        '--use_symlinks', 
+        action='store_true', 
+        help='Whether to use symbolic links or copy image data'
+    )
 
     args = vars(ap.parse_args())
     raw_filepath = args['filepath']
@@ -156,6 +163,7 @@ try:
     PhysicalSizeZ, PhysicalSizeY, PhysicalSizeX = zyx_physical_sizes
 
     to_h5 = args['to_h5']
+    use_symlinks = args['use_symlinks']
 
     time_range_to_save_li = args['time_range_to_save'].split()
     timeRangeToSave = [int(val) for val in time_range_to_save_li]
@@ -176,7 +184,7 @@ try:
                 reader, series, images_path, filename_no_ext, s0p,
                 chName, c, {}, SizeT, SizeZ, TimeIncrement, PhysicalSizeZ,
                 PhysicalSizeY, PhysicalSizeX, to_h5, 
-                timeRangeToSave
+                timeRangeToSave, use_symlinks, raw_filepath, lazy_load
                 )
             pbar.update()
         pbar.close()

--- a/cellacdc/acdc_bioio_bioformats/_save_data.py
+++ b/cellacdc/acdc_bioio_bioformats/_save_data.py
@@ -12,138 +12,138 @@ from cellacdc import acdc_bioio_bioformats as bioformats
 import argparse
 
 ap = bioformats._utils.setup_argparser()
+ap.add_argument(
+    '-f', 
+    '--filepath', 
+    required=True, 
+    type=str, 
+    metavar='FILEPATH',
+    help='Filepath of the raw microscopy file.'
+)
+
+ap.add_argument(
+    '-d', 
+    '--do_save_channels', 
+    type=str,
+    required=True, 
+    metavar='DO_SAVE_CHANNELS',
+    help='Whether to save the channel or not.'
+)
+
+ap.add_argument(
+    '-c', 
+    '--channel_names', 
+    type=str,
+    required=True, 
+    metavar='CHANNEL_NAMES',
+    help='List of channel names.'
+)
+
+ap.add_argument(
+    '-s', 
+    '--series_idx', 
+    required=True, 
+    type=int, 
+    metavar='SERIES_IDX',
+    help='Index of the Position in the microscopy file.'
+)
+
+ap.add_argument(
+    '-i', 
+    '--images_path', 
+    required=True, 
+    type=str, 
+    metavar='IMAGE_PATH',
+    help='Images folder path.'
+)
+
+ap.add_argument(
+    '-p', 
+    '--filename_no_ext', 
+    required=True, 
+    type=str, 
+    metavar='FILENAME_NO_EXT',
+    help='Name of the file without extension.'
+)
+
+ap.add_argument(
+    '-pos', 
+    '--pos_idx_str', 
+    required=True, 
+    type=str, 
+    metavar='POS_IDX_STR',
+    help='String index of the Position padded with required zeros.'
+)
+
+ap.add_argument(
+    '-t', 
+    '--SizeT', 
+    required=True, 
+    type=int, 
+    metavar='SIZET',
+    help='Number of timepoints in the microscopy file.'
+)
+
+ap.add_argument(
+    '-z', 
+    '--SizeZ', 
+    required=True, 
+    type=int, 
+    metavar='SIZEZ',
+    help='Number of z-slices in a single z-stack.'
+)
+
+ap.add_argument(
+    '-time_increment', 
+    '--time_increment', 
+    type=float, 
+    required=True, 
+    metavar='TIME_INCREMENT',
+    help='Time between consecutive frames in seconds.'
+)
+
+ap.add_argument(
+    '-zyx', 
+    '--zyx_physical_sizes', 
+    type=str,
+    required=True, 
+    metavar='ZYX_PHYSICAL_SIZES',
+    help='Physical sizes in z, y, x dimensions.'
+)
+
+ap.add_argument(
+    '-to_h5', 
+    '--to_h5', 
+    action='store_true', 
+    help='Whether to save with h5 file format.'
+)
+
+ap.add_argument(
+    '-r', 
+    '--time_range_to_save', 
+    type=str,
+    required=True, 
+    metavar='TIME_RANGE_TO_SAVE',
+    help='Start and end frame to save.'
+)
+
+ap.add_argument(
+    '-a', 
+    '--all', 
+    action='store_true', 
+    help='Whether to read entire position into RAM or not.'
+)
+
+ap.add_argument(
+    '-u', 
+    '--use_symlinks', 
+    action='store_true', 
+    help='Whether to use symbolic links or copy image data'
+)
+
+args = vars(ap.parse_args())
 
 try:
-    ap.add_argument(
-        '-f', 
-        '--filepath', 
-        required=True, 
-        type=str, 
-        metavar='FILEPATH',
-        help='Filepath of the raw microscopy file.'
-    )
-
-    ap.add_argument(
-        '-d', 
-        '--do_save_channels', 
-        type=str,
-        required=True, 
-        metavar='DO_SAVE_CHANNELS',
-        help='Whether to save the channel or not.'
-    )
-
-    ap.add_argument(
-        '-c', 
-        '--channel_names', 
-        type=str,
-        required=True, 
-        metavar='CHANNEL_NAMES',
-        help='List of channel names.'
-    )
-
-    ap.add_argument(
-        '-s', 
-        '--series_idx', 
-        required=True, 
-        type=int, 
-        metavar='SERIES_IDX',
-        help='Index of the Position in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-i', 
-        '--images_path', 
-        required=True, 
-        type=str, 
-        metavar='IMAGE_PATH',
-        help='Images folder path.'
-    )
-
-    ap.add_argument(
-        '-p', 
-        '--filename_no_ext', 
-        required=True, 
-        type=str, 
-        metavar='FILENAME_NO_EXT',
-        help='Name of the file without extension.'
-    )
-
-    ap.add_argument(
-        '-pos', 
-        '--pos_idx_str', 
-        required=True, 
-        type=str, 
-        metavar='POS_IDX_STR',
-        help='String index of the Position padded with required zeros.'
-    )
-
-    ap.add_argument(
-        '-t', 
-        '--SizeT', 
-        required=True, 
-        type=int, 
-        metavar='SIZET',
-        help='Number of timepoints in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-z', 
-        '--SizeZ', 
-        required=True, 
-        type=int, 
-        metavar='SIZEZ',
-        help='Number of z-slices in a single z-stack.'
-    )
-
-    ap.add_argument(
-        '-time_increment', 
-        '--time_increment', 
-        type=float, 
-        required=True, 
-        metavar='TIME_INCREMENT',
-        help='Time between consecutive frames in seconds.'
-    )
-
-    ap.add_argument(
-        '-zyx', 
-        '--zyx_physical_sizes', 
-        type=str,
-        required=True, 
-        metavar='ZYX_PHYSICAL_SIZES',
-        help='Physical sizes in z, y, x dimensions.'
-    )
-
-    ap.add_argument(
-        '-to_h5', 
-        '--to_h5', 
-        action='store_true', 
-        help='Whether to save with h5 file format.'
-    )
-
-    ap.add_argument(
-        '-r', 
-        '--time_range_to_save', 
-        type=str,
-        required=True, 
-        metavar='TIME_RANGE_TO_SAVE',
-        help='Start and end frame to save.'
-    )
-    
-    ap.add_argument(
-        '-a', 
-        '--all', 
-        action='store_true', 
-        help='Whether to read entire position into RAM or not.'
-    )
-    
-    ap.add_argument(
-        '-u', 
-        '--use_symlinks', 
-        action='store_true', 
-        help='Whether to use symbolic links or copy image data'
-    )
-
-    args = vars(ap.parse_args())
     raw_filepath = args['filepath']
     do_save_channels_li = args['do_save_channels'].split()
     do_save_channels = [val=='True' for val in do_save_channels_li]
@@ -189,7 +189,5 @@ try:
             pbar.update()
         pbar.close()
 except Exception as err:
-    args = vars(ap.parse_args())
-    uuid4 = args['uuid']
-    
+    uuid4 = args['uuid4']
     bioformats._utils.dump_exception(err, uuid4)

--- a/cellacdc/acdc_bioio_bioformats/_save_data_single_channel.py
+++ b/cellacdc/acdc_bioio_bioformats/_save_data_single_channel.py
@@ -144,6 +144,13 @@ try:
         action='store_true', 
         help='Whether to read entire position into RAM or not.'
     )
+    
+    ap.add_argument(
+        '-u', 
+        '--use_sym_links', 
+        action='store_true', 
+        help='Whether to use symbolic links or copy image data'
+    )
 
     args = vars(ap.parse_args())
     raw_filepath = args['filepath']
@@ -167,6 +174,7 @@ try:
     PhysicalSizeZ, PhysicalSizeY, PhysicalSizeX = zyx_physical_sizes
 
     to_h5 = args['to_h5']
+    use_symlinks = args['use_symlinks']
 
     time_range_to_save_li = args['time_range_to_save'].split()
     timeRangeToSave = [int(val) for val in time_range_to_save_li]
@@ -177,7 +185,7 @@ try:
             reader, series, images_path, filename_no_ext, s0p,
             channel_name, 0, {}, SizeT, SizeZ, TimeIncrement, PhysicalSizeZ,
             PhysicalSizeY, PhysicalSizeX, to_h5, 
-            timeRangeToSave
+            timeRangeToSave, use_symlinks, raw_filepath, lazy_load
         )
 except Exception as err:
     args = vars(ap.parse_args())

--- a/cellacdc/acdc_bioio_bioformats/_save_data_single_channel.py
+++ b/cellacdc/acdc_bioio_bioformats/_save_data_single_channel.py
@@ -12,147 +12,146 @@ from cellacdc import acdc_bioio_bioformats as bioformats
 import argparse
 
 ap = bioformats._utils.setup_argparser()
+ap.add_argument(
+    '-f', 
+    '--filepath', 
+    required=True, 
+    type=str, 
+    metavar='FILEPATH',
+    help='Filepath of the raw microscopy file.'
+)
+
+ap.add_argument(
+    '-d', 
+    '--do_save_channels', 
+    type=str,
+    required=True, 
+    metavar='DO_SAVE_CHANNELS',
+    help='Whether to save the channel or not.'
+)
+
+ap.add_argument(
+    '-c', 
+    '--channel_name', 
+    type=str, 
+    required=True, 
+    metavar='CHANNEL_NAMES',
+    help='Channel name'
+)
+
+ap.add_argument(
+    '-ch_idx', 
+    '--ch_idx', 
+    required=True, 
+    type=int, 
+    metavar='CH_IDX',
+    help='Index of the channel.'
+)
+
+ap.add_argument(
+    '-z', 
+    '--SizeZ', 
+    required=True, 
+    type=int, 
+    metavar='SIZEZ',
+    help='Number of z-slices in a single z-stack.'
+)
+
+ap.add_argument(
+    '-s', 
+    '--series_idx', 
+    required=True, 
+    type=int, 
+    metavar='SERIES_IDX',
+    help='Index of the Position in the microscopy file.'
+)
+
+ap.add_argument(
+    '-i', 
+    '--images_path', 
+    required=True, 
+    type=str, 
+    metavar='IMAGE_PATH',
+    help='Images folder path.'
+)
+
+ap.add_argument(
+    '-p', 
+    '--filename_no_ext', 
+    required=True, 
+    type=str, 
+    metavar='FILENAME_NO_EXT',
+    help='Name of the file without extension.'
+)
+
+ap.add_argument(
+    '-pos', 
+    '--pos_idx_str', 
+    required=True, 
+    type=str, 
+    metavar='POS_IDX_STR',
+    help='String index of the Position padded with required zeros.'
+)
+
+ap.add_argument(
+    '-t', 
+    '--SizeT', 
+    required=True, 
+    type=int, 
+    metavar='SIZET',
+    help='Number of timepoints in the microscopy file.'
+)
+
+ap.add_argument(
+    '-time_increment', 
+    '--time_increment', 
+    type=float, 
+    required=True, 
+    metavar='TIME_INCREMENT',
+    help='Time between consecutive frames in seconds.'
+)
+
+ap.add_argument(
+    '-zyx', 
+    '--zyx_physical_sizes', 
+    type=str,
+    required=True, 
+    metavar='ZYX_PHYSICAL_SIZES',
+    help='Physical sizes in z, y, x dimensions.'
+)
+
+ap.add_argument(
+    '-to_h5', 
+    '--to_h5', 
+    action='store_true', 
+    help='Whether to save with h5 file format.'
+)
+
+ap.add_argument(
+    '-r', 
+    '--time_range_to_save', 
+    type=str,
+    required=True, 
+    metavar='TIME_RANGE_TO_SAVE',
+    help='Start and end frame to save.'
+)
+
+ap.add_argument(
+    '-a', 
+    '--all', 
+    action='store_true', 
+    help='Whether to read entire position into RAM or not.'
+)
+
+ap.add_argument(
+    '-u', 
+    '--use_symlinks', 
+    action='store_true', 
+    help='Whether to use symbolic links or copy image data'
+)
+args = vars(ap.parse_args())
 
 try:
-    ap.add_argument(
-        '-f', 
-        '--filepath', 
-        required=True, 
-        type=str, 
-        metavar='FILEPATH',
-        help='Filepath of the raw microscopy file.'
-    )
-
-    ap.add_argument(
-        '-d', 
-        '--do_save_channels', 
-        type=str,
-        required=True, 
-        metavar='DO_SAVE_CHANNELS',
-        help='Whether to save the channel or not.'
-    )
-
-    ap.add_argument(
-        '-c', 
-        '--channel_name', 
-        type=str, 
-        required=True, 
-        metavar='CHANNEL_NAMES',
-        help='Channel name'
-    )
-
-    ap.add_argument(
-        '-ch_idx', 
-        '--ch_idx', 
-        required=True, 
-        type=int, 
-        metavar='CH_IDX',
-        help='Index of the channel.'
-    )
-
-    ap.add_argument(
-        '-z', 
-        '--SizeZ', 
-        required=True, 
-        type=int, 
-        metavar='SIZEZ',
-        help='Number of z-slices in a single z-stack.'
-    )
-
-    ap.add_argument(
-        '-s', 
-        '--series_idx', 
-        required=True, 
-        type=int, 
-        metavar='SERIES_IDX',
-        help='Index of the Position in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-i', 
-        '--images_path', 
-        required=True, 
-        type=str, 
-        metavar='IMAGE_PATH',
-        help='Images folder path.'
-    )
-
-    ap.add_argument(
-        '-p', 
-        '--filename_no_ext', 
-        required=True, 
-        type=str, 
-        metavar='FILENAME_NO_EXT',
-        help='Name of the file without extension.'
-    )
-
-    ap.add_argument(
-        '-pos', 
-        '--pos_idx_str', 
-        required=True, 
-        type=str, 
-        metavar='POS_IDX_STR',
-        help='String index of the Position padded with required zeros.'
-    )
-
-    ap.add_argument(
-        '-t', 
-        '--SizeT', 
-        required=True, 
-        type=int, 
-        metavar='SIZET',
-        help='Number of timepoints in the microscopy file.'
-    )
-
-    ap.add_argument(
-        '-time_increment', 
-        '--time_increment', 
-        type=float, 
-        required=True, 
-        metavar='TIME_INCREMENT',
-        help='Time between consecutive frames in seconds.'
-    )
-
-    ap.add_argument(
-        '-zyx', 
-        '--zyx_physical_sizes', 
-        type=str,
-        required=True, 
-        metavar='ZYX_PHYSICAL_SIZES',
-        help='Physical sizes in z, y, x dimensions.'
-    )
-
-    ap.add_argument(
-        '-to_h5', 
-        '--to_h5', 
-        action='store_true', 
-        help='Whether to save with h5 file format.'
-    )
-
-    ap.add_argument(
-        '-r', 
-        '--time_range_to_save', 
-        type=str,
-        required=True, 
-        metavar='TIME_RANGE_TO_SAVE',
-        help='Start and end frame to save.'
-    )
-    
-    ap.add_argument(
-        '-a', 
-        '--all', 
-        action='store_true', 
-        help='Whether to read entire position into RAM or not.'
-    )
-    
-    ap.add_argument(
-        '-u', 
-        '--use_sym_links', 
-        action='store_true', 
-        help='Whether to use symbolic links or copy image data'
-    )
-
-    args = vars(ap.parse_args())
     raw_filepath = args['filepath']
     do_save_channels_li = args['do_save_channels'].split()
     do_save_channels = [val=='True' for val in do_save_channels_li]
@@ -188,7 +187,6 @@ try:
             timeRangeToSave, use_symlinks, raw_filepath, lazy_load
         )
 except Exception as err:
-    args = vars(ap.parse_args())
-    uuid4 = args['uuid']
+    uuid4 = args['uuid4']
     
     bioformats._utils.dump_exception(err, uuid4)

--- a/cellacdc/acdc_bioio_bioformats/_utils.py
+++ b/cellacdc/acdc_bioio_bioformats/_utils.py
@@ -238,7 +238,7 @@ def load_image_data_from_symlink(
         channel_name: str, 
     ):
     section_name = f'channel_name.{channel_name}'
-    section = cp_symlink[section]
+    section = cp_symlink[section_name]
     source_filepath = section['source_filepath']
     frames_range = section['frames_range']
     zslices_range = section['zslices_range']

--- a/cellacdc/acdc_bioio_bioformats/_utils.py
+++ b/cellacdc/acdc_bioio_bioformats/_utils.py
@@ -221,7 +221,7 @@ def save_symlink(
         series_index: int,
         lazy_load: bool
     ):
-    cp_symlink[channel_name] = {
+    cp_symlink[f'channel_name.{channel_name}'] = {
         'source_filepath': source_filepath,
         'frames_range': ','.join([str(val) for val in frames_range]),
         'zslices_range': ','.join([str(val) for val in zslices_range]),
@@ -237,12 +237,14 @@ def load_image_data_from_symlink(
         cp_symlink: ConfigParser,
         channel_name: str, 
     ):
-    source_filepath = cp_symlink[channel_name]['source_filepath']
-    frames_range = cp_symlink[channel_name]['frames_range']
-    zslices_range = cp_symlink[channel_name]['zslices_range']
-    channel_index = int(cp_symlink[channel_name]['channel_index'])
-    series_index = int(cp_symlink[channel_name]['series_index'])
-    lazy_load = cp_symlink[channel_name].getboolean('lazy_load')
+    section_name = f'channel_name.{channel_name}'
+    section = cp_symlink[section]
+    source_filepath = section['source_filepath']
+    frames_range = section['frames_range']
+    zslices_range = section['zslices_range']
+    channel_index = int(section['channel_index'])
+    series_index = int(section['series_index'])
+    lazy_load = section.getboolean('lazy_load')
     frames_range = [int(val) for val in frames_range.split(',')]
     zslices_range = [int(val) for val in zslices_range.split(',')]
     

--- a/cellacdc/acdc_bioio_bioformats/_utils.py
+++ b/cellacdc/acdc_bioio_bioformats/_utils.py
@@ -12,6 +12,9 @@ import numpy as np
 import h5py
 
 from cellacdc import myutils, bioio_sample_data_folderpath
+from cellacdc.config import ConfigParser
+
+from cellacdc.acdc_bioio_bioformats import ImageReader
 
 def setup_argparser():
     ap = argparse.ArgumentParser(
@@ -53,6 +56,61 @@ def getFilename(
     else:
         return filename
 
+def read_img_data(
+        reader, 
+        ch_idx, 
+        series, 
+        framesRange, 
+        zslicesRange,
+        img_data_container,
+        use_symlinks=False,
+        to_h5=False,
+    ):
+    numFrames = len(framesRange)
+    SizeZ = len(zslicesRange)
+    num_imgs = numFrames*SizeZ
+    pbar = tqdm(
+        total=num_imgs, 
+        ncols=100, 
+        desc=f'Reading image (z 0/{SizeZ}, t 0/{numFrames})'
+    )
+    for out_t, t in enumerate(framesRange):
+        imgData_z = []
+        for z in zslicesRange:
+            pbar.set_description(
+                f'Reading image (z {z+1}/{SizeZ}, t {out_t+1}/{numFrames})'
+            )
+            idx = None
+            imgData = reader.read(
+                c=ch_idx, 
+                z=z, 
+                t=t, 
+                series=series, 
+                rescale=False,
+                index=idx
+            )
+            if use_symlinks:
+                pass
+            elif to_h5:
+                img_data_container[out_t, z] = imgData
+            else:
+                imgData_z.append(imgData)
+            
+            pbar.update()
+
+        if to_h5:
+            continue
+        
+        if use_symlinks:
+            continue
+        
+        imgData_z = np.squeeze(np.array(imgData_z, dtype=imgData.dtype))
+        img_data_container.append(imgData_z)
+        
+    pbar.close()
+    
+    return img_data_container
+
 def saveImgDataChannel(
         reader, 
         series: int, 
@@ -70,9 +128,20 @@ def saveImgDataChannel(
         PhysicalSizeX: float,
         to_h5: bool, 
         timeRangeToSave: Tuple[int, int],
+        use_symlinks: bool,
+        src_data_filepath: os.PathLike, 
+        lazy_load: bool,
     ):
     savedSizeT = timeRangeToSave[1] - timeRangeToSave[0] + 1
-    if to_h5:
+    if use_symlinks:
+        filename = getFilename(
+            filenameNOext, s0p, 'symlink', series, '.ini'
+        )
+        symlink_ini_filepath = os.path.join(images_path, filename)
+        cp_symlink = ConfigParser()
+        if os.path.exists(symlink_ini_filepath):
+            cp_symlink.read(symlink_ini_filepath)
+    elif to_h5:
         filename = getFilename(
             filenameNOext, s0p, chName, series, '.h5'
         )
@@ -99,42 +168,38 @@ def saveImgDataChannel(
         imgData_ch = []
 
     framesRange = range(timeRangeToSave[0]-1, timeRangeToSave[1])
+    zslicesRange = range(SizeZ)
     filePath = os.path.join(images_path, filename)
-    dimsIdx = {'c': ch_idx} 
-    numFrames = len(framesRange)
-    num_imgs = numFrames*SizeZ
-    pbar = tqdm(
-        total=num_imgs, 
-        ncols=100, 
-        desc=f'Reading image (z 0/{SizeZ}, t 0/{numFrames})'
+    imgData_ch = read_img_data(
+        reader, 
+        ch_idx, 
+        series, 
+        framesRange, 
+        zslicesRange,
+        imgData_ch,
+        use_symlinks=use_symlinks,
+        to_h5=to_h5,
     )
-    for out_t, t in enumerate(framesRange):
-        imgData_z = []
-        dimsIdx['t'] = t
-        for z in range(SizeZ):
-            pbar.set_description(
-                f'Reading image (z {z+1}/{SizeZ}, t {out_t+1}/{numFrames})'
-            )
-            dimsIdx['z'] = z
-            idx = None
-            imgData = reader.read(
-                c=ch_idx, z=z, t=t, series=series, rescale=False,
-                index=idx
-            )
-            if to_h5:
-                imgData_ch[out_t, z] = imgData
-            else:
-                imgData_z.append(imgData)
-            
-            pbar.update()
 
-        if not to_h5:
-            imgData_z = np.squeeze(np.array(imgData_z, dtype=imgData.dtype))
-            imgData_ch.append(imgData_z)
-    pbar.close()
-
-    if not to_h5:
-        imgData_ch = np.squeeze(np.array(imgData_ch, dtype=imgData.dtype))
+    if use_symlinks:
+        save_symlink(
+            cp_symlink,
+            symlink_ini_filepath,
+            chName, 
+            src_data_filepath,
+            (timeRangeToSave[0]-1, timeRangeToSave[1]),
+            (0, SizeZ),
+            ch_idx,
+            series,
+            lazy_load
+        )
+    elif to_h5:
+        h5f.close()
+        shutil.move(tempFilepath, filePath)
+        shutil.rmtree(tempDir)
+    else:
+        imgData_first = imgData_ch[0][0]
+        imgData_ch = np.squeeze(np.array(imgData_ch, dtype=imgData_first.dtype))
         myutils.to_tiff(
             filePath, imgData_ch, 
             SizeT=savedSizeT,
@@ -144,10 +209,59 @@ def saveImgDataChannel(
             PhysicalSizeY=PhysicalSizeY,
             PhysicalSizeX=PhysicalSizeX,
         )
-    else:
-        h5f.close()
-        shutil.move(tempFilepath, filePath)
-        shutil.rmtree(tempDir)
+
+def save_symlink(
+        cp_symlink: ConfigParser,
+        symlink_ini_filepath: os.PathLike,
+        channel_name: str, 
+        source_filepath: os.PathLike,
+        frames_range: tuple[int],
+        zslices_range: tuple[int],
+        channel_index: int,
+        series_index: int,
+        lazy_load: bool
+    ):
+    cp_symlink[channel_name] = {
+        'source_filepath': source_filepath,
+        'frames_range': ','.join([str(val) for val in frames_range]),
+        'zslices_range': ','.join([str(val) for val in zslices_range]),
+        'channel_index': str(channel_index),
+        'series_index': str(series_index),
+        'lazy_load': str(lazy_load)
+    }
+    
+    with open(symlink_ini_filepath, 'w') as configfile:
+        cp_symlink.write(configfile)
+
+def load_image_data_from_symlink(
+        cp_symlink: ConfigParser,
+        channel_name: str, 
+    ):
+    source_filepath = cp_symlink[channel_name]['source_filepath']
+    frames_range = cp_symlink[channel_name]['frames_range']
+    zslices_range = cp_symlink[channel_name]['zslices_range']
+    channel_index = int(cp_symlink[channel_name]['channel_index'])
+    series_index = int(cp_symlink[channel_name]['series_index'])
+    lazy_load = cp_symlink[channel_name].getboolean('lazy_load')
+    frames_range = [int(val) for val in frames_range.split(',')]
+    zslices_range = [int(val) for val in zslices_range.split(',')]
+    
+    img_data_container = []
+    with ImageReader(source_filepath, lazy_load=lazy_load) as reader:
+        img_data_container = read_img_data(
+            reader, 
+            channel_index, 
+            series_index, 
+            range(*frames_range), 
+            range(*zslices_range),
+            img_data_container,
+            use_symlinks=False,
+            to_h5=False,
+        )
+    dtype = img_data_container[0][0].dtype
+    img_data = np.squeeze(np.array(img_data_container, dtype=dtype))
+    
+    return img_data
 
 def dump_exception(err, error_id):
     import pickle

--- a/cellacdc/acdc_bioio_bioformats/_utils.py
+++ b/cellacdc/acdc_bioio_bioformats/_utils.py
@@ -133,6 +133,7 @@ def saveImgDataChannel(
         lazy_load: bool,
     ):
     savedSizeT = timeRangeToSave[1] - timeRangeToSave[0] + 1
+    imgData_ch = []
     if use_symlinks:
         filename = getFilename(
             filenameNOext, s0p, 'symlink', series, '.ini'
@@ -165,7 +166,6 @@ def saveImgDataChannel(
         filename = getFilename(
             filenameNOext, s0p, chName, series, '.tif'
         )
-        imgData_ch = []
 
     framesRange = range(timeRangeToSave[0]-1, timeRangeToSave[1])
     zslicesRange = range(SizeZ)

--- a/cellacdc/acdc_bioio_bioformats/_utils.py
+++ b/cellacdc/acdc_bioio_bioformats/_utils.py
@@ -227,7 +227,8 @@ def save_symlink(
         'zslices_range': ','.join([str(val) for val in zslices_range]),
         'channel_index': str(channel_index),
         'series_index': str(series_index),
-        'lazy_load': str(lazy_load)
+        'lazy_load': str(lazy_load),
+        'use_bioio': 'True',
     }
     
     with open(symlink_ini_filepath, 'w') as configfile:

--- a/cellacdc/acdc_bioio_bioformats/reader.py
+++ b/cellacdc/acdc_bioio_bioformats/reader.py
@@ -11,15 +11,11 @@ from . import EXTENSION_METADATA_ATTR_MAPPER
 
 def set_reader(image_filepath, **kwargs):
     if 'reader' in kwargs:
-        return kwargs
+        return kwargs, {}
     
     _, ext = os.path.splitext(image_filepath)
     if ext in EXTENSION_PACKAGE_MAPPER:
-        all_kwargs = {
-            **kwargs, 
-            **EXTENSION_BIOIMAGE_KWARGS_MAPPER.get(ext, {})
-        }
-        return all_kwargs
+        return kwargs, EXTENSION_BIOIMAGE_KWARGS_MAPPER.get(ext, {})
     
     try:
         import bioio_bioformats
@@ -30,7 +26,7 @@ def set_reader(image_filepath, **kwargs):
             'Bioformats', 'Bioformats reader is not installed'
         )
     
-    return kwargs
+    return kwargs, {}
 
 class ImageReader:
     def __init__(
@@ -44,15 +40,23 @@ class ImageReader:
         
         # Capture BioImage error and install required dependencies
         try:
-            kwargs = set_reader(image_filepath, **kwargs)
-            self._bioioimage = BioImage(image_filepath, **kwargs)
+            kwargs, other_kwargs = set_reader(image_filepath, **kwargs)
+            try:
+                all_kwargs = {**kwargs, **other_kwargs}
+                self._bioioimage = BioImage(image_filepath, **all_kwargs)
+            except Exception as err:
+                self._bioioimage = BioImage(image_filepath, **kwargs)
         except UnsupportedFileFormatError as err:
             install.install_reader_dependencies(
                 image_filepath, err, 
                 qparent=qparent
             )
-            kwargs = set_reader(image_filepath, **kwargs)
-            self._bioioimage = BioImage(image_filepath, **kwargs)
+            kwargs, other_kwargs = set_reader(image_filepath, **kwargs)
+            try:
+                all_kwargs = {**kwargs, **other_kwargs}
+                self._bioioimage = BioImage(image_filepath, **all_kwargs)
+            except Exception as err:
+                self._bioioimage = BioImage(image_filepath, **kwargs)
         
         self._is_lazy_load = lazy_load
         

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -3377,7 +3377,7 @@ class QDialogMetadataXML(QDialog):
                 "it is very likely that metadata from the metadata reader\n"
                 "will be correct also for all the next positions.\n\n"
                 "Click this button to stop showing this dialog and use\n"
-                "the metadata from the reader\n"
+                "the metadata from the reader for all the next files.\n"
                 "(except for channel names, I will use the manually entered)"
             )
             buttonsLayout.addWidget(trustButton, 1, 1)

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -10052,6 +10052,8 @@ class QtSelectItems(QDialog):
         multiPosButton.setCheckable(True)
         self.multiPosButton = multiPosButton
         bottomLayout.addWidget(multiPosButton, alignment=Qt.AlignLeft)
+        
+        self.buttonsLayout = bottomLayout
 
         listBox = widgets.listWidget()
         listBox.addItems(items)
@@ -10081,6 +10083,11 @@ class QtSelectItems(QDialog):
 
         self.setFont(font)
 
+    def setAllSelected(self, selected: bool):
+        for i in range(self.ListBox.count()):
+            item = self.ListBox.item(i)
+            item.setSelected(selected)
+    
     def setSelectedItems(self, selectedItemsText):
         if self.multiPosButton.isChecked():
             for i in range(self.ListBox.count()):
@@ -19246,13 +19253,14 @@ class SelectFoldersToAnalyse(QBaseDialog):
             onlyExpPaths=False, 
             scanFolderTree=True,
             instructionsText='Select experiment folders to analyse',
-            askSelectPosFolders=False
+            askSelectPosFolders=False,
+            title='Select experiments to analyse'
         ):
         super().__init__(parent)
         
         self.cancel = True
         self.onlyExpPaths = onlyExpPaths
-        self.setWindowTitle('Select experiments to analyse')
+        self.setWindowTitle(title)
         self.scanTree = scanFolderTree
         self.askSelectPosFolders = askSelectPosFolders
         
@@ -19309,7 +19317,10 @@ class SelectFoldersToAnalyse(QBaseDialog):
         
         mainLayout.addSpacing(20)
         mainLayout.addLayout(buttonsLayout)
-        mainLayout.addStretch(1)
+        mainLayout.setStretch(0, 0)
+        mainLayout.setStretch(1, 0)
+        mainLayout.setStretch(2, 1)
+        mainLayout.setStretch(3, 0)
         
         self.setLayout(mainLayout)
         
@@ -19399,10 +19410,16 @@ class SelectFoldersToAnalyse(QBaseDialog):
             return list(exp_paths.keys())
         
         paths = []
+        doNotAskAgain = False
         for exp_path, pos_foldernames in exp_paths.items():
             if len(pos_foldernames) == 1:
                 paths.append(exp_path)
                 continue
+            
+            if doNotAskAgain:
+                for pos in pos_foldernames:
+                    paths.append(os.path.join(exp_path, pos))
+                    continue
             
             informativeText = html_utils.paragraph(
                 'The following experiment folder<br><br>'
@@ -19415,10 +19432,17 @@ class SelectFoldersToAnalyse(QBaseDialog):
             select_folder.QtPrompt(
                 self, values, toggleMulti=True, 
                 informativeText=informativeText,
-                selectedValues=values
+                selectedValues=values, 
+                addDoNotAskAgain=True
             )
             if select_folder.cancel:
                 return
+            
+            if select_folder.doNotAskAgain:
+                doNotAskAgain = True
+                for pos in pos_foldernames:
+                    paths.append(os.path.join(exp_path, pos))
+                    continue
             
             for pos in select_folder.selected_pos:
                 paths.append(os.path.join(exp_path, pos))

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -10918,7 +10918,8 @@ class QDialogZsliceAbsent(QDialog):
         buttonsLayout = QGridLayout()
 
         txt = html_utils.paragraph(f"""
-            You loaded the fluorescent file called<br><br>{filename}<br><br>
+            You loaded the fluorescent file called<br><br>
+            <code>{filename}</code><br><br>
             however you <b>never selected which z-slice</b><br> you want to use
             when calculating metrics<br> (e.g., mean, median, amount...etc.)<br><br>
             Choose one of following options:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -9569,6 +9569,7 @@ class QLineEditDialog(QDialog):
 
         # Add layouts
         mainLayout.addLayout(LineEditLayout)
+        mainLayout.addSpacing(20)
         mainLayout.addLayout(buttonsLayout)
 
         self.setLayout(mainLayout)

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -19419,7 +19419,7 @@ class SelectFoldersToAnalyse(QBaseDialog):
             if doNotAskAgain:
                 for pos in pos_foldernames:
                     paths.append(os.path.join(exp_path, pos))
-                    continue
+                continue
             
             informativeText = html_utils.paragraph(
                 'The following experiment folder<br><br>'
@@ -19442,7 +19442,7 @@ class SelectFoldersToAnalyse(QBaseDialog):
                 doNotAskAgain = True
                 for pos in pos_foldernames:
                     paths.append(os.path.join(exp_path, pos))
-                    continue
+                continue
             
             for pos in select_folder.selected_pos:
                 paths.append(os.path.join(exp_path, pos))

--- a/cellacdc/cli.py
+++ b/cellacdc/cli.py
@@ -1354,47 +1354,7 @@ class ComputeMeasurementsKernel(_WorkflowKernel):
         
     def _load_channel_data(self, channel_path):
         self.log(f'Loading fluorescence image data from "{channel_path}"...')
-        images_path = os.path.dirname(channel_path)
-        bkgrData = None
-        # Load overlay frames and align if needed
-        filename = os.path.basename(channel_path)
-        filename_noEXT, ext = os.path.splitext(filename)
-        if ext == '.npy' or ext == '.npz':
-            img_data = np.load(channel_path)
-            try:
-                img_data = np.squeeze(img_data['arr_0'])
-            except Exception as e:
-                img_data = np.squeeze(img_data)
-
-            # Load background data
-            bkgrData_path = os.path.join(
-                images_path, f'{filename_noEXT}_bkgrRoiData.npz'
-            )
-            if os.path.exists(bkgrData_path):
-                bkgrData = np.load(bkgrData_path)
-        elif ext == '.tif' or ext == '.tiff':
-            aligned_filename = f'{filename_noEXT}_aligned.npz'
-            aligned_path = os.path.join(images_path, aligned_filename)
-            if os.path.exists(aligned_path):
-                img_data = np.load(aligned_path)['arr_0']
-
-                # Load background data
-                bkgrData_path = os.path.join(
-                    images_path, f'{aligned_filename}_bkgrRoiData.npz'
-                )
-                if os.path.exists(bkgrData_path):
-                    bkgrData = np.load(bkgrData_path)
-            else:
-                img_data = np.squeeze(skimage.io.imread(channel_path))
-
-                # Load background data
-                bkgrData_path = os.path.join(
-                    images_path, f'{filename_noEXT}_bkgrRoiData.npz'
-                )
-                if os.path.exists(bkgrData_path):
-                    bkgrData = np.load(bkgrData_path)
-        else:
-            return None, None
+        img_data, bkgrData = load.load_image_and_bkgr_data(channel_path)
 
         return img_data, bkgrData
     

--- a/cellacdc/dataPrep.py
+++ b/cellacdc/dataPrep.py
@@ -3035,7 +3035,7 @@ class dataPrepWin(QMainWindow):
             user_ch_name = ch_name_selector.user_ch_name
 
         user_ch_file_paths = load.get_user_ch_paths(
-                self.images_paths, user_ch_name
+            self.images_paths, user_ch_name
         )
         self.AutoPilotProfile.storeSelectedChannel(user_ch_name)
 

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -909,6 +909,9 @@ class bioFormatsWorker(QObject):
                 
                 if not self.lazy_load:
                     command = f'{command}, -a'
+                
+                if self.useSymLink:
+                    command = f'{command}, -u'
                     
                 args = [sys.executable, _process.__file__, '-c', command]
                 subprocess.run(args)
@@ -976,6 +979,9 @@ class bioFormatsWorker(QObject):
                     )
                     if self.to_h5:
                         command = f'{command}, -to_h5'
+                    
+                    if self.useSymLink:
+                        command = f'{command}, -u'
                     
                     args = [sys.executable, _process.__file__, '-c', command]
                     subprocess.run(args)
@@ -1081,10 +1087,11 @@ class bioFormatsWorker(QObject):
                         self.cancelled = True
                         break
                 
-                cancel = self.emitAskUseSymLink()
-                if cancel:
-                    self.cancelled = True
-                    break
+                if p == 0:
+                    cancel = self.emitAskUseSymLink()
+                    if cancel:
+                        self.cancelled = True
+                        break
                 
                 self.numPos = len(self.rawFilenames)
                 self.numPosDigits = len(str(self.numPos))
@@ -2192,7 +2199,7 @@ class createDataStructWin(QMainWindow):
             important_text, admonition_type='important'
         )
         txt = html_utils.paragraph(f"""
-            Cell-ACDC can either copy the image data to TIFF files, or use 
+            Cell-ACDC can either copy the image data to TIFF or H5 files, or use 
             symbolic links to the source image data.<br><br>
             
             A symbolic link is a special type of file that acts as a pointer or alias, 
@@ -2213,6 +2220,7 @@ class createDataStructWin(QMainWindow):
             )
         )
         self.worker.useSymLink = msg.clickedButton == useSymLinkButton
+        self.worker.cancel = msg.cancel
         self.waitCond.wakeAll()
     
     def askPosFoldersExisting(self, exp_dst_path):

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -80,6 +80,7 @@ class bioFormatsWorker(QObject):
     )
     critical = Signal(object)
     sigFinishedReadingSampleImageData = Signal(object)
+    sigAskUseSymLink = Signal()
 
     def __init__(
             self, raw_src_path, rawFilenames, exp_dst_path,
@@ -528,7 +529,7 @@ class bioFormatsWorker(QObject):
 
             if self.metadataWin.cancel:
                 return True
-
+            
             if not self.metadataWin.requestedReadingSampleImageDataAgain:
                 break
             LensNA = self.metadataWin.LensNA
@@ -1023,6 +1024,13 @@ class bioFormatsWorker(QObject):
                         except Exception as e:
                             self.progress.emit(e)
 
+    def emitAskUseSymLink(self):
+        self.mutex.lock()
+        self.sigAskUseSymLink.emit()
+        self.waitCond.wait(self.mutex)
+        self.mutex.unlock()
+        return self.cancel
+    
     @worker_exception_handler
     def run(self):
         raw_src_path = self.raw_src_path
@@ -1036,7 +1044,7 @@ class bioFormatsWorker(QObject):
             
         self.cancelled = False
         self.isCriticalError = False
-        
+        self.useSymLink = False
         for p, filename in enumerate(self.rawFilenames):
             pos_n = p + self.start_pos_n
             if self.rawDataStruct == 0:
@@ -1045,7 +1053,13 @@ class bioFormatsWorker(QObject):
                     if cancel:
                         self.cancelled = True
                         break
-
+                
+                if p == 0:
+                    cancel = self.emitAskUseSymLink()
+                    if cancel:
+                        self.cancelled = True
+                        break
+                
                 self.numPos = self.SizeS
                 self.numPosDigits = len(str(self.numPos))
                 if p == 0:
@@ -1066,6 +1080,12 @@ class bioFormatsWorker(QObject):
                     if cancel:
                         self.cancelled = True
                         break
+                
+                cancel = self.emitAskUseSymLink()
+                if cancel:
+                    self.cancelled = True
+                    break
+                
                 self.numPos = len(self.rawFilenames)
                 self.numPosDigits = len(str(self.numPos))
                 if p == 0:
@@ -1088,14 +1108,19 @@ class bioFormatsWorker(QObject):
         if self.rawDataStruct == 2:
             filename = self.rawFilenames[0]
             if not self.overWriteMetadata:
-                abort = self.readMetadata(raw_src_path, filename)
-                if abort:
+                cancel = self.readMetadata(raw_src_path, filename)
+                if cancel:
                     self.cancelled = True
                     if self.bioformats_backend == 'python-bioformats':
                         javabridge.kill_vm()
                     self.finished.emit()
                     return
-      
+                
+            cancel = self.emitAskUseSymLink()
+            if cancel:
+                self.cancelled = True
+                return
+            
             self.numPos = len(self.posNums)
             self.numPosDigits = len(str(self.numPos))
             self.initPbar.emit(self.numPos*self.SizeC)
@@ -1646,6 +1671,7 @@ class createDataStructWin(QMainWindow):
         self.worker.critical.connect(self.workerCritical)
         self.worker.criticalError.connect(self.criticalBioFormats)
         self.worker.confirmMetadata.connect(self.askConfirmMetadata)
+        self.worker.sigAskUseSymLink.connect(self.askUseSymLink)
         self.thread.started.connect(self.worker.run)
 
         self.thread.start()
@@ -2155,6 +2181,40 @@ class createDataStructWin(QMainWindow):
         self.worker.metadataWin = self.metadataWin
         self.waitCond.wakeAll()
 
+    def askUseSymLink(self):
+        msg = widgets.myMessageBox(wrapText=False)
+        important_text = ("""
+            If you choose to use symbolic links, the source data file(s) cannot 
+            be moved from their current location, otherwise the link will 
+            be broken.
+        """)
+        important_admon = html_utils.to_admonition(
+            important_text, admonition_type='important'
+        )
+        txt = html_utils.paragraph(f"""
+            Cell-ACDC can either copy the image data to TIFF files, or use 
+            symbolic links to the source image data.<br><br>
+            
+            A symbolic link is a special type of file that acts as a pointer or alias, 
+            referring to another file by its path rather than its content.<br><br>
+            
+            With symbolic links, <b>no image data will be copied</b> and only files 
+            you will generate later (e.g., segmentation data)<br>
+            will be created in the respective Position folders.<br>
+            {important_admon}<br>
+            What do you want to do?
+        """)
+        _, copyButton, useSymLinkButton = msg.question(
+            self, 'Use symbolic links?', txt, 
+            buttonsTexts=(
+                'Cancel', 
+                widgets.copyPushButton('Copy image data to TIFF files'),
+                widgets.SegmentPushButton('Use symbolic links')
+            )
+        )
+        self.worker.useSymLink = msg.clickedButton == useSymLinkButton
+        self.waitCond.wakeAll()
+    
     def askPosFoldersExisting(self, exp_dst_path):
         pos_foldernames = myutils.get_pos_foldernames(exp_dst_path)
         if not pos_foldernames:

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2696,7 +2696,6 @@ class CreateSymLinkToPosWin(QMainWindow):
             dst_folderpath, 
             exp_segm_files_to_copy_mapper
         ):
-        printl(exp_segm_files_to_copy_mapper)
         self._worker_thread = QThread()
         
         self._worker = workers.CreateSymLinkToPosWinWorker(

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2215,7 +2215,7 @@ class createDataStructWin(QMainWindow):
             self, 'Use symbolic links?', txt, 
             buttonsTexts=(
                 'Cancel', 
-                widgets.copyPushButton('Copy image data to TIFF files'),
+                widgets.copyPushButton('Copy image data into Position folders'),
                 widgets.SegmentPushButton('Use symbolic links')
             )
         )

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2502,7 +2502,7 @@ class CreateSymLinkToPosWin(QMainWindow):
         infoText = html_utils.paragraph("""
             This module allows you to create symbolic links to your 
             existing Position folders, instead of copying the raw microscopy files into them.<br><br>
-            To so so, follow the instructions in the pop-up windows.<br><br>
+            To do so, follow the instructions in the pop-up windows.<br><br>
             Progress will be displayed below.
         """)
         

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -1272,6 +1272,7 @@ class createDataStructWin(QMainWindow):
 
         cancelButton = widgets.cancelPushButton(' Stop process ')
         cancelButton.clicked.connect(self.close)
+        self.cancelButton = cancelButton
         
         buttonsLayout = QHBoxLayout()
         buttonsLayout.addStretch(1)
@@ -1644,6 +1645,8 @@ class createDataStructWin(QMainWindow):
                 self.close()
                 return
 
+        self.cancelButton.setEnabled(False)
+        
         # Set up separate thread for bioFormatsWorker class
         self.mutex = QMutex()
         self.waitCond = QWaitCondition()
@@ -2519,6 +2522,7 @@ class CreateSymLinkToPosWin(QMainWindow):
         buttonsLayout = QHBoxLayout()
         cancelButton = widgets.cancelPushButton(' Close ')
         cancelButton.clicked.connect(self.cancelProcess)
+        self.cancelButton = cancelButton
         
         buttonsLayout.addStretch(1)
         buttonsLayout.addWidget(cancelButton)
@@ -2582,6 +2586,7 @@ class CreateSymLinkToPosWin(QMainWindow):
             self.cancelProcess()
             return
         
+        self.cancelButton.setEnabled(False)
         self.startWorker(
             expToPosFoldersMapper, 
             dst_folderpath, 

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2533,7 +2533,7 @@ class CreateSymLinkToPosWin(QMainWindow):
             parent=self, 
             instructionsText=
                 'Select experiment or specific <b>Position folders '
-                'to link<b>',
+                'to link</b>',
             askSelectPosFolders=True,
             title='Select Position folders to link'
         )

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2708,6 +2708,7 @@ class CreateSymLinkToPosWin(QMainWindow):
             dst_folderpath, 
             exp_segm_files_to_copy_mapper
         )
+        self._worker.moveToThread(self._worker_thread)
         self._worker.success = False
 
         self._worker.signals.finished.connect(

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import logging
 
 from typing import Literal
 
@@ -46,6 +47,7 @@ from . import acdc_fiji_path
 from . import fiji_macros
 from . import acdc_regex
 from . import io
+from . import workers
 
 if os.name == 'nt':
     try:
@@ -1180,20 +1182,20 @@ class createDataStructWin(QMainWindow):
         ):
         super().__init__(parent)
 
+        if version is None:
+            version = myutils.read_version()
+        
         self._version = version
 
         logger, logs_path, log_path, log_filename = myutils.setupLogger(
-            module='dataStruct'
+            module='dataStruct-bioformats'
         )
         self.logger = logger
         self.log_path = log_path
         self.log_filename = log_filename
         self.logs_path = logs_path
 
-        if self._version is not None:
-            logger.info(f'Initializing Data structure module v{self._version}...')
-        else:
-            logger.info(f'Initializing Data structure module...')
+        logger.info(f'Initializing Data structure module v{self._version}...')
 
         self.start_JVM = start_JVM
         self.allowExit = allowExit
@@ -1205,7 +1207,6 @@ class createDataStructWin(QMainWindow):
             settings_csv_path, index_col='setting'
         )
 
-        version = myutils.read_version()
         self.setWindowTitle(f"Cell-ACDC v{version} - Data structure")
         self.setWindowIcon(QtGui.QIcon(":icon.ico"))
 
@@ -1269,12 +1270,12 @@ class createDataStructWin(QMainWindow):
         self.logWin.setReadOnly(True)
         mainLayout.addWidget(self.logWin)
 
-        abortButton = widgets.cancelPushButton(' Stop processs ')
-        abortButton.clicked.connect(self.close)
+        cancelButton = widgets.cancelPushButton(' Stop processs ')
+        cancelButton.clicked.connect(self.close)
         
         buttonsLayout = QHBoxLayout()
         buttonsLayout.addStretch(1)
-        buttonsLayout.addWidget(abortButton)
+        buttonsLayout.addWidget(cancelButton)
         
         mainLayout.addLayout(buttonsLayout)
 
@@ -2463,4 +2464,316 @@ class InitFijiMacro:
     def cancel(self):
         self.logger.info('Running Bio-Formats from Fiji process cancelled.')
         
+class CreateSymLinkToPosWin(QMainWindow):
+    def __init__(
+            self, 
+            parent=None, 
+            version=None
+        ):
+        super().__init__(parent)
         
+        self.cancel = True
+
+        self._version = version
+        
+        self.logWin = QPlainTextEdit()
+        self.logWin.setReadOnly(True)
+
+        logger, logs_path, log_path, log_filename = myutils.setupLogger(
+            module='dataStruct-symLinkToPos', QLogWidget=self.logWin
+        )
+        self.logger = logger
+        self.log_path = log_path
+        self.log_filename = log_filename
+        self.logs_path = logs_path     
+        
+        logger.info(
+            'Initializing Data structure module (symbolic link to Positions) '
+            f'v{self._version}...'
+        )
+
+        mainContainer = QWidget()
+        self.setCentralWidget(mainContainer)
+        
+        mainLayout = QVBoxLayout()
+        
+        mainContainer.setLayout(mainLayout)
+        
+        infoText = html_utils.paragraph("""
+            This module allows you to create symbolic links to your 
+            existing Position folders, instead of copying the raw microscopy files into them.<br><br>
+            To so so, follow the instructions in the pop-up windows.<br><br>
+            Progress will be displayed below.
+        """)
+        
+        infoLabel = QLabel(infoText)
+        
+        self.pbar = widgets.ProgressBarWithETA()
+        self.pbar.setValue(0)
+        self.pbar.setMaximum(0)
+        
+        mainLayout.addWidget(infoLabel)
+        mainLayout.addWidget(self.pbar)
+        mainLayout.addWidget(self.logWin)
+        
+        buttonsLayout = QHBoxLayout()
+        cancelButton = widgets.cancelPushButton(' Close ')
+        cancelButton.clicked.connect(self.cancelProcess)
+        
+        buttonsLayout.addStretch(1)
+        buttonsLayout.addWidget(cancelButton)
+        
+        mainLayout.addSpacing(20)
+        mainLayout.addLayout(buttonsLayout)
+    
+    def main(self):
+        self.logger.info('Creating symbolic links to Position folders started.')
+        self.logger.info('Asking to select Position folders...')
+        selectFoldersWin = apps.SelectFoldersToAnalyse(
+            parent=self, 
+            instructionsText=
+                'Select experiment or specific <b>Position folders '
+                'to link<b>',
+            askSelectPosFolders=True,
+            title='Select Position folders to link'
+        )
+        selectFoldersWin.exec_()
+        if selectFoldersWin.cancel:
+            self.cancelProcess()
+            return
+        
+        expToPosFoldersMapper = (
+            selectFoldersWin.selectedExpFolderToPosFoldernamesMapper
+        )
+        
+        tot_num_pos = sum([
+            len(pos_folders) 
+            for _, pos_folders in expToPosFoldersMapper.items()
+        ])
+        self.pbar.setMaximum(tot_num_pos)
+        
+        text = html_utils.paragraph("""
+            The newly created folders with the symbolic links will 
+            have the <b>same folder structure of the source folders</b>.<br><br>
+            You will now be asked to <b>select the destination folder</b> where to 
+            create all new experiment folders.
+        """)
+        msg = widgets.myMessageBox(wrapText=False)
+        msg.information(self, 'Select destination folder', text)
+        if msg.cancel:
+            self.cancelProcess()
+            return
+        
+        dst_folderpath = apps.get_existing_directory(
+            allow_images_path=False,
+            parent=self, 
+            caption='Select folder where to save configuration file',
+            basedir=myutils.getMostRecentPath(),
+            # options=QFileDialog.DontUseNativeDialog
+        )
+        if not dst_folderpath:
+            self.cancelProcess()
+            return
+        
+        exp_segm_files_to_copy_mapper = self.askSegmFilesToCopy(
+            expToPosFoldersMapper
+        )
+        if exp_segm_files_to_copy_mapper is None:
+            self.cancelProcess()
+            return
+        
+        self.startWorker(
+            expToPosFoldersMapper, 
+            dst_folderpath, 
+            exp_segm_files_to_copy_mapper
+        )
+        success = self.waitWorker()
+        
+        if success:
+            self.log_succes(dst_folderpath)
+        else:
+            self.log_failure()
+        
+        self.cancel = False
+        self.close()
+    
+    def log_succes(self, dst_folderpath):
+        self.logger.info('Symbolic links created successfully!')
+        
+        text = html_utils.paragraph(f"""
+            Symbolic links created successfully!<br><br>
+            Destination folder:
+            <copiable>{dst_folderpath}</copiable>
+        """)
+        msg = widgets.myMessageBox(wrapText=False)
+        msg.information(
+            self, 'Symbolic links created successfully!', text,
+            path_to_browse=dst_folderpath
+        )
+    
+    def log_failure(self):
+        self.logger.info('Failed creating symbolic links to Position folders.')
+        
+        text = html_utils.paragraph(f"""
+            Failed creating symbolic links to Position folders :(.<br><br>
+            More information in the terminal or in the following log file:
+            <copiable>{self.log_path}</copiable>
+        """)
+        msg = widgets.myMessageBox(wrapText=False)
+        msg.warning(
+            self, 'Symbolic links creation failed', text,
+            path_to_browse=self.logs_path,
+            browse_button_text='Browse log files folder'
+        )
+    
+    def closeEvent(self, event):
+        try:
+            self.loop.exit()
+        except Exception as err:
+            pass
+    
+    def askSegmFilesToCopy(self, exp_pos_mapper):
+        text = html_utils.paragraph("""
+            If existing, Cell-ACDC can <b>copy the segmentation files</b> to 
+            the newly created Position folders<br><br>
+            You can choose to copy all of them, or let Cell-ACDC ask you 
+            specific files to copy.<br><br>
+            How do you want to proceed?
+        """)
+        msg = widgets.myMessageBox(wrapText=False)
+        _, noButton, copyAllButton, selectButton = msg.question(
+            self, 
+            'Copy segmentation files?', 
+            text,
+            buttonsTexts=(
+                'Cancel', 
+                'No, do not copy segm. files', 
+                widgets.copyPushButton('Copy all segm. files'), 
+                widgets.setPushButton('Let me select segm. files to copy')
+            )
+        )
+        if msg.cancel:
+            return
+        
+        if msg.clickedButton == noButton:
+            exp_segm_files_mapper = {
+                exp_path: [] for exp_path in exp_pos_mapper.keys()
+            }
+            return exp_segm_files_mapper
+        
+        exp_segm_files_mapper = {}
+        copy_all = msg.clickedButton == copyAllButton
+        for exp_path, pos_foldernames in exp_pos_mapper.items():
+            existingSegmEndNames = load.get_segm_endnames_from_exp_path(
+                exp_path
+            )
+            
+            if copy_all:
+                exp_segm_files_mapper[exp_path] = list(existingSegmEndNames)
+                continue
+            
+            images_path = os.path.join(exp_path, pos_foldernames[0], 'Images')
+            basename = load.get_basename(images_path)
+            
+            win = apps.SelectSegmFileDialog(
+                existingSegmEndNames, 
+                exp_path, 
+                parent=self,
+                basename=basename,
+                allowMultipleSelection=True
+            )
+            win.exec_()
+            if win.cancel:
+                return
+            
+            exp_segm_files_mapper[exp_path] = list(win.selectedItemTexts)
+        
+        return exp_segm_files_mapper
+    
+    def startWorker(
+            self, 
+            exp_pos_mapper, 
+            dst_folderpath, 
+            exp_segm_files_to_copy_mapper
+        ):
+        printl(exp_segm_files_to_copy_mapper)
+        self._worker_thread = QThread()
+        
+        self._worker = workers.CreateSymLinkToPosWinWorker(
+            exp_pos_mapper, 
+            dst_folderpath, 
+            exp_segm_files_to_copy_mapper
+        )
+        self._worker.success = False
+
+        self._worker.signals.finished.connect(
+            self._worker_thread.quit
+        )
+        self._worker.signals.finished.connect(
+            self._worker.deleteLater
+        )
+        self._worker.signals.finished.connect(self._worker_thread.deleteLater)
+        
+        self._worker.signals.progress.connect(self.workerProgress)
+        self._worker.signals.progressBar.connect(self.workerUpdateProgressbar)
+        self._worker.signals.finished.connect(self.workerFinished)
+        self._worker.signals.critical.connect(self.workerCritical)
+        
+        self._worker_thread.started.connect( self._worker.run)
+        self._worker_thread.start()
+    
+    def workerProgress(self, text, loggerLevel='INFO'):
+        self.logger.log(getattr(logging, loggerLevel), text)
+    
+    def workerUpdateProgressbar(self, step):
+        self.pbar.update(step)
+    
+    @exception_handler
+    def workerCritical(self, worker_out: tuple[QObject, Exception]):
+        worker, error = worker_out
+        self._worker.success = False
+        try:
+            self.loop.exit()
+        except Exception as err:
+            pass
+        
+        try:
+            self._worker.thread().quit()
+            self._worker.deleteLater()
+            self._worker.thread().deleteLater()
+        except Exception as err:
+            # Worker already closed
+            pass
+        
+        raise error
+    
+    def waitWorker(self):
+        self.loop = QEventLoop()
+        self.loop.exec_()
+        
+        return self._worker.success
+    
+    def workerFinished(self):
+        self._worker.success = True
+        try:
+            self.loop.exit()
+        except Exception as err:
+            pass
+    
+    def cancelProcess(self):
+        try:
+            self.loop.exit()
+        except Exception as err:
+            pass
+        
+        text = html_utils.paragraph(f"""
+            Creating symbolic links to Position folders process cancelled.
+        """)
+        msg = widgets.myMessageBox(wrapText=False)
+        msg.warning(
+            self, 'Symbolic links creation cancelled', text,
+            path_to_browse=self.logs_path,
+            browse_button_text='Browse log files folder'
+        )
+
+        self.close()

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -1270,7 +1270,7 @@ class createDataStructWin(QMainWindow):
         self.logWin.setReadOnly(True)
         mainLayout.addWidget(self.logWin)
 
-        cancelButton = widgets.cancelPushButton(' Stop processs ')
+        cancelButton = widgets.cancelPushButton(' Stop process ')
         cancelButton.clicked.connect(self.close)
         
         buttonsLayout = QHBoxLayout()

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -98,8 +98,8 @@ from . import debugutils
 
 from .plot import imshow
 from . import gui_utils
-
 from . import gui_combine
+from . import valid_image_data_ends
 
 np.seterr(invalid='ignore')
 
@@ -23368,13 +23368,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         # Load overlay frames and align if needed
         filename = os.path.basename(fluo_path)
         filename_noEXT, ext = os.path.splitext(filename)
+        fluo_data = load.load_image_file(fluo_path)
         if ext == '.npy' or ext == '.npz':
-            fluo_data = np.load(fluo_path)
-            try:
-                fluo_data = np.squeeze(fluo_data['arr_0'])
-            except Exception as e:
-                fluo_data = np.squeeze(fluo_data)
-
             # Load background data
             bkgrData_path = os.path.join(
                 posData.images_path, f'{filename_noEXT}_bkgrRoiData.npz'
@@ -23385,8 +23380,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             aligned_filename = f'{filename_noEXT}_aligned.npz'
             aligned_path = os.path.join(posData.images_path, aligned_filename)
             if os.path.exists(aligned_path):
-                fluo_data = np.load(aligned_path)['arr_0']
-
                 # Load background data
                 bkgrData_path = os.path.join(
                     posData.images_path, f'{aligned_filename}_bkgrRoiData.npz'
@@ -23394,23 +23387,15 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 if os.path.exists(bkgrData_path):
                     bkgrData = np.load(bkgrData_path)
             else:
-                fluo_data = self.loadNonAlignedFluoChannel(fluo_path)
-                if fluo_data is None:
-                    return None, None
-
                 # Load background data
                 bkgrData_path = os.path.join(
                     posData.images_path, f'{filename_noEXT}_bkgrRoiData.npz'
                 )
                 if os.path.exists(bkgrData_path):
                     bkgrData = np.load(bkgrData_path)
-        elif isGuiThread:
-            txt = html_utils.paragraph(
-                f'File format {ext} is not supported!\n'
-                'Choose either .tif or .npz files.'
-            )
-            msg = widgets.myMessageBox()
-            msg.critical(self, 'File not supported', txt)
+        elif ext.startswith('.ini;;'):
+            ...
+        else:
             return None, None
 
         return fluo_data, bkgrData
@@ -24948,27 +24933,31 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.zSliceOverlay_SB.valueChanged.disconnect()
             self.zProjOverlay_CB.currentTextChanged.disconnect()
             self.zProjOverlay_CB.activated.disconnect()
-
-
+            
     def criticalFluoChannelNotFound(self, fluo_ch, posData):
-        msg = widgets.myMessageBox(showCentered=False)
+        msg = widgets.myMessageBox(showCentered=False, wrapText=False)
         ls = "\n".join(myutils.listdir(posData.images_path))
-        msg.setDetailedText(
+        detailsText = (
             f'Files present in the {posData.relPath} folder:\n'
             f'{ls}'
         )
         title = 'Requested channel data not found!'
-        txt = html_utils.paragraph(
-            f'The folder <code>{posData.pos_path}</code> '
-            '<b>does not contain</b> '
-            'either one of the following files:<br><br>'
-            f'{posData.basename}{fluo_ch}.tif<br>'
-            f'{posData.basename}{fluo_ch}_aligned.npz<br><br>'
-            'Data loading aborted.'
-        )
-        msg.addShowInFileManagerButton(posData.images_path)
-        okButton = msg.warning(
-            self, title, txt, buttonsTexts=('Ok')
+        href = f'<a href="{issues_url}">GitHub page</a>'
+        txt = html_utils.paragraph(f"""
+            The folder
+            <copiable>{posData.images_path}</copiable>
+            <b>does not contain</b> valid image data files.<br><br>
+            Valid files are <code>.tif</code>, 
+            <code>_aligned.npz</code>, <code>.h5</code>, 
+            or <code>_symlink.ini</code>.<br><br>
+            If you need help understanding this, feel free to contact us by 
+            opening an issue on our {href}.<br><br>
+            Thank you for your patience!
+        """)
+        msg.warning(
+            self, title, txt, buttonsTexts=('Ok'), 
+            path_to_browse=posData.images_path,
+            detailsText=detailsText,
         )
 
     def imgGradLUTfinished_cb(self):
@@ -30302,24 +30291,22 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         )
 
     def getPathFromChName(self, chName, posData):
-        ls = myutils.listdir(posData.images_path)
-        endnames = {f[len(posData.basename):]:f for f in ls}
-        validEnds = ['_aligned.npz', '_aligned.h5', '.h5', '.tif', '.npz']
-        for end in validEnds:
-            files = [
-                filename for endname, filename in endnames.items()
-                if endname == f'{chName}{end}'
-            ]
-            if files:
-                filename = files[0]
-                break
-        else:
-            self.criticalFluoChannelNotFound(chName, posData)
+        channel_file_path = load.get_filename_from_channel(
+            posData.images_path, chName
+        )
+        if not channel_file_path:
             self.app.restoreOverrideCursor()
             return None, None
 
-        fluo_path = os.path.join(posData.images_path, filename)
-        filename, _ = os.path.splitext(filename)
+        # The function `get_filename_from_channel` will append ';;channel_name' 
+        # when the imgPath is the symlink.ini file
+        parts = channel_file_path.split(';;')
+        fluo_path = channel_file_path
+        if len(parts) == 2:
+            filename = os.path.basename(channel_file_path)
+        else:
+            filename, _ = os.path.splitext(filename)
+            
         return fluo_path, filename
     
     def loadPosTriggered(self):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29450,7 +29450,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             symlink_filepath = load.save_symlink_ini_from_image_filepath(
                 file_path, exp_path, channel_name
             )
-            self._openFolder(exp_path=exp_path, imageFilePath=symlink_filepath)
+            self._openFolder(
+                exp_path=exp_path, 
+                imageFilePath=symlink_filepath,
+                user_ch_name=channel_name
+            )
         elif ext == '.tif' or ext == '.npz':
             new_filepath = os.path.join(exp_path, new_filename)
             if not os.path.exists(new_filepath):
@@ -29756,7 +29760,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
 
     @exception_handler
     def _openFolder(
-            self, checked=False, exp_path=None, imageFilePath=''
+            self, 
+            checked=False, 
+            exp_path=None, 
+            imageFilePath='', 
+            user_ch_name=None
         ):
         """Main function to load data.
 
@@ -29816,7 +29824,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         ch_name_selector = prompts.select_channel_name(
             which_channel='segm', allow_abort=False
         )
-        user_ch_name = None
         if not is_pos_folder and not is_images_folder and not imageFilePath:
             images_paths = self._loadFromExperimentFolder(exp_path)
             if not images_paths:
@@ -29841,9 +29848,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             )
             filename = os.path.basename(imageFilePath)
             self.ch_names = ch_names
-            user_ch_name = [
-                chName for chName in ch_names if filename.find(chName)!=-1
-            ][0]
+            if user_ch_name is None:
+                user_ch_name = [
+                    chName for chName in ch_names if filename.find(chName)!=-1
+                ][0]
             images_paths = [exp_path]
             pos_path = os.path.dirname(exp_path)
             exp_path = os.path.dirname(pos_path)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29290,13 +29290,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.updateAllImages()
         self.logger.info('Annotations correctly recovered.')
 
-    def askUserChannelName(self, filename_no_ext, ext):
-        help_txt = html_utils.paragraph(f"""
-            Cell-ACDC requires that every image file has a basename and some 
-            additional text, typically the channel name.<br><br>
-            The basename will be common to all created files, while the additional text is used to identify the image files.
-        """)
-
+    def askUserChannelName(self, filename_no_ext):
         basename = filename_no_ext
         underscore_splits = filename_no_ext.split('_')
         if len(underscore_splits) > 1:
@@ -29306,32 +29300,38 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             channel_name = 'channel_1'
         
         txt = html_utils.paragraph(f"""
-            Provide some text (e.g., the channel name) to append at the end of the image file.
+            Provide some text (e.g., the channel name) to identify the image file.
         """)
-        win = apps.filenameDialog(
-            basename=basename,
-            ext=ext,
-            hintText=txt,
-            defaultEntry=channel_name,
-            helpText=help_txt, 
-            allowEmpty=False,
+        
+        win = apps.QLineEditDialog(
+            title='Provide id text for image file',
+            msg=txt,
+            defaultTxt=channel_name,
             parent=self,
-            title='Provide channel name for image file',
+            allowEmpty=False,
+            allowText=True
         )
         win.exec_()
         if win.cancel:
-            return False, ''
-
-        return True, win.entryText
+            return True, ''
+        
+        return False, win.enteredValue
     
-    def warnUserCreationImagesFolder(self, images_path, ext):
+    def askUserCreationImagesFolder(self, images_path, ext):
         msg = widgets.myMessageBox(wrapText=False)
         txt = (f"""
             Cell-ACDC requires a specific folder structure to load the data.<br><br>
             Specifically, it requires the <b>image(s) to be located in a
             folder called <code>Images</code></b>.<br><br>
-            The <b>file format</b> of the images must be <b>TIFF or NPZ</b> 
-            (.tif or .npz extension).<br><br>
+            The <b>file format</b> of the images must be <b>TIFF, H5, or NPZ</b> 
+            (.tif, .h5, or .npz extension).<br><br>
+            However, Cell-ACDC can also create a <b>symbolic link</b> to the image file.<br><br> 
+            A symbolic link is a special type of file that acts as a pointer or alias,<br>
+            referring to another file by its path rather than its content.<br><br>
+            With the symbolic link, no data will be copied or moved, but the 
+            source data file's location<br>
+            cannot change, otherwise the link will be broken.<br><br>
+            Note that any new file created by Cell-ACDC will be saved in the newly created <code>Images</code> folder (see below).<br><br>            
             You can choose to let Cell-ACDC create the required data structure 
             from your file,<br>
             or you can stop the 
@@ -29341,14 +29341,14 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             folder:
             <copiable>{images_path}</copiable>
             <br>
+            How do you want to proceed?
         """)
-        
-        if ext == '.tif' or ext == '.npz':
-            txt = f'{txt}How do you want to proceed?'
-        else:
-            txt = f'{txt}Do you want to proceed?'
         txt = html_utils.paragraph(txt)
-        
+        symlinkButton = widgets.SegmentPushButton(
+            'Create symbolic link to the image'
+        )
+        copyButton = None
+        moveButton = None
         if ext == '.tif' or ext == '.npz':
             copyButton = widgets.copyPushButton(
                 'Copy the image into the new folder'
@@ -29356,27 +29356,26 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             moveButton = widgets.movePushButton(
                 'Move the image into the new folder'
             )
-            _, copyButton, moveButton = msg.information(
-                self, 'Creating Images folder', txt, 
-                buttonsTexts=('Cancel', copyButton, moveButton)
+            buttonsTexts = (
+                'Cancel', 
+                copyButton, 
+                moveButton,
+                symlinkButton
             )
-            if msg.cancel:
-                return False, None
-
-            if msg.clickedButton == copyButton:
-                return True, True
-            elif msg.clickedButton == moveButton:
-                return True, False
-        
         else:
-            msg.information(
-                self, 'Creating Images folder', txt, 
-                buttonsTexts=('Cancel', 'Yes, proceed')
+            copyButton = widgets.copyPushButton(
+                'Create grayscale TIFF file in the new folder'
             )
-            if msg.cancel:
-                return False, None
-            
-            return True, True
+            buttonsTexts=('Cancel', copyButton, symlinkButton)
+        
+        msg.information(
+            self, 'Creating Images folder', txt, buttonsTexts=buttonsTexts
+        )
+        do_copy = msg.clickedButton == copyButton
+        do_move = msg.clickedButton == moveButton
+        use_symlink = msg.clickedButton == symlinkButton
+        
+        return msg.cancel, do_copy, do_move, use_symlink
 
     @exception_handler
     def _openFile(self, file_path=None):
@@ -29403,15 +29402,14 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
             acdc_folder = f'{timestamp}_acdc'
             exp_path = os.path.join(dirpath, acdc_folder, 'Images')
-            proceed, do_copy = self.warnUserCreationImagesFolder(exp_path, ext)
-            if not proceed:
+            out = self.askUserCreationImagesFolder(exp_path, ext)
+            cancel, do_copy, do_move, use_symlink = out
+            if cancel:
                 self.logger.info('Loading image file cancelled.')
                 return
             
-            proceed, channel_name = self.askUserChannelName(
-                filename, '.tif'
-            )
-            if not proceed:
+            cancel, channel_name = self.askUserChannelName(filename)
+            if cancel:
                 self.logger.info('Loading image file cancelled.')
                 return
             
@@ -29430,8 +29428,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             basename = f'{filename}_'
             new_filename = f'{filename}_{channel_name}{ext}'
             df_metadata = pd.DataFrame({
-                'Description': ['basename'],
-                'values': [basename]
+                'Description': ['basename', 'channel_0_name'],
+                'values': [basename, channel_name]
             })
             metadata_csv_filename = f'{basename}metadata.csv'
             metadata_csv_filepath = os.path.join(
@@ -29443,10 +29441,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         if do_copy:
             action_text = 'Copying'
-        else:
+        elif do_move:
             action_text = 'Moving'
+        elif use_symlink:
+            action_text = 'Creating symbolic link'
         
-        if ext == '.tif' or ext == '.npz':
+        if use_symlink:
+            symlink_filepath = load.save_symlink_ini_from_image_filepath(
+                file_path, exp_path, channel_name
+            )
+            self._openFolder(exp_path=exp_path, imageFilePath=symlink_filepath)
+        elif ext == '.tif' or ext == '.npz':
             new_filepath = os.path.join(exp_path, new_filename)
             if not os.path.exists(new_filepath):
                 self.logger.info(f'{action_text} file to Images folder...')

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -29397,6 +29397,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         filename = filename.rstrip('_')
         channel_name = None
         do_copy = True
+        do_move = False
+        use_symlink = False
         if dirname != 'Images':
             timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
             acdc_folder = f'{timestamp}_acdc'
@@ -29438,6 +29440,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         else:
             new_filename = f'{filename}{ext}'
         
+        action_text = ''
         if do_copy:
             action_text = 'Copying'
         elif do_move:
@@ -29454,7 +29457,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 imageFilePath=symlink_filepath,
                 user_ch_name=channel_name
             )
-        elif ext == '.tif' or ext == '.npz':
+        elif ext == '.tif' or ext == '.npz' or ext == '.tiff':
             new_filepath = os.path.join(exp_path, new_filename)
             if not os.path.exists(new_filepath):
                 self.logger.info(f'{action_text} file to Images folder...')

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -31147,7 +31147,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     win.selectedChannel, _posData
                 )
                 cellacdc_df = _posData.segmInfo_df.loc[srcFilename].copy()
-                _, dstFilename = self.getPathAndFilenameNoExtFromChName(channel_name, _posData)
+                _, dstFilename = self.getPathAndFilenameNoExtFromChName(
+                    channel_name, _posData
+                )
                 if dstFilename is None:
                     self.worker.abort = True
                     self.waitCond.wakeAll()
@@ -31197,9 +31199,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             dataPrepWin.SizeT = self.data[0].SizeT
             dataPrepWin.SizeZ = self.data[0].SizeZ
             dataPrepWin.metadataAlreadyAsked = True
-            self.logger.info(f'Loading channel {user_ch_name} data...')
+            self.logger.info(f'Loading channel {channel_name} data...')
             dataPrepWin.loadFiles(
-                exp_path, user_ch_file_paths, user_ch_name
+                exp_path, user_ch_file_paths, channel_name
             )
             dataPrepWin.startAction.setDisabled(True)
             dataPrepWin.onlySelectingZslice = True

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -99,7 +99,6 @@ from . import debugutils
 from .plot import imshow
 from . import gui_utils
 from . import gui_combine
-from . import valid_image_data_ends
 
 np.seterr(invalid='ignore')
 

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -3186,7 +3186,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             image_data = posData.img_data
         else:
             channel = imageItem.channelName
-            _, filename = self.getPathFromChName(channel, posData)
+            _, filename = self.getPathAndFilenameNoExtFromChName(channel, posData)
             image_data = posData.fluo_data_dict[filename]
         
         triggeredByUser = True
@@ -6121,7 +6121,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         selectedChannel = intensMeasurQGBox.channelCombobox.currentText()
         
         try:
-            _, filename = self.getPathFromChName(selectedChannel, posData)
+            _, filename = self.getPathAndFilenameNoExtFromChName(selectedChannel, posData)
             image = posData.ol_data_dict[filename][posData.frame_i]
         except Exception as e:
             image = posData.img_data[posData.frame_i]
@@ -23363,41 +23363,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
 
     def load_fluo_data(self, fluo_path, isGuiThread=True):
         self.logger.info(f'Loading fluorescence image data from "{fluo_path}"...')
-        bkgrData = None
-        posData = self.data[self.pos_i]
-        # Load overlay frames and align if needed
-        filename = os.path.basename(fluo_path)
-        filename_noEXT, ext = os.path.splitext(filename)
-        fluo_data = load.load_image_file(fluo_path)
-        if ext == '.npy' or ext == '.npz':
-            # Load background data
-            bkgrData_path = os.path.join(
-                posData.images_path, f'{filename_noEXT}_bkgrRoiData.npz'
-            )
-            if os.path.exists(bkgrData_path):
-                bkgrData = np.load(bkgrData_path)
-        elif ext == '.tif' or ext == '.tiff':
-            aligned_filename = f'{filename_noEXT}_aligned.npz'
-            aligned_path = os.path.join(posData.images_path, aligned_filename)
-            if os.path.exists(aligned_path):
-                # Load background data
-                bkgrData_path = os.path.join(
-                    posData.images_path, f'{aligned_filename}_bkgrRoiData.npz'
-                )
-                if os.path.exists(bkgrData_path):
-                    bkgrData = np.load(bkgrData_path)
-            else:
-                # Load background data
-                bkgrData_path = os.path.join(
-                    posData.images_path, f'{filename_noEXT}_bkgrRoiData.npz'
-                )
-                if os.path.exists(bkgrData_path):
-                    bkgrData = np.load(bkgrData_path)
-        elif ext.startswith('.ini;;'):
-            ...
-        else:
-            return None, None
-
+        fluo_data, bkgrData = load.load_image_and_bkgr_data(fluo_path)
         return fluo_data, bkgrData
 
     def setOverlayColors(self):
@@ -23448,7 +23414,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             else:
                 ol_data = {}
             for i, ol_ch in enumerate(ol_channels):
-                _, filename = self.getPathFromChName(ol_ch, posData)
+                _, filename = self.getPathAndFilenameNoExtFromChName(ol_ch, posData)
                 ol_data[filename] = (
                     posData.ol_data_dict[filename].copy()
                 )                        
@@ -24538,7 +24504,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 action.weighingData.append(wData)
                 continue
 
-            path, filename = self.getPathFromChName(weighingChannel, posData)
+            path, filename = self.getPathAndFilenameNoExtFromChName(weighingChannel, posData)
             if path is None:
                 self.criticalFluoChannelNotFound(weighingChannel, posData) 
                 action.weighingData = []
@@ -30112,7 +30078,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             if channelName not in posData.loadedFluoChannels:
                 self.loadOverlayData([channelName], addToExisting=True)
             else:
-                _, filename = self.getPathFromChName(channelName, posData)
+                _, filename = self.getPathAndFilenameNoExtFromChName(channelName, posData)
                 posData.ol_data[filename] = (
                     posData.ol_data_dict[filename].copy()
                 )
@@ -30290,24 +30256,24 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             'Load fluorescence images?', msg.clickedButton.text()
         )
 
-    def getPathFromChName(self, chName, posData):
+    def getPathAndFilenameNoExtFromChName(self, chName, posData):
         channel_file_path = load.get_filename_from_channel(
             posData.images_path, chName
         )
         if not channel_file_path:
             self.app.restoreOverrideCursor()
             return None, None
-
+        
         # The function `get_filename_from_channel` will append ';;channel_name' 
         # when the imgPath is the symlink.ini file
-        parts = channel_file_path.split(';;')
-        fluo_path = channel_file_path
-        if len(parts) == 2:
-            filename = os.path.basename(channel_file_path)
+        filename = os.path.basename(channel_file_path)
+        filename_no_ext, ext = os.path.splitext(filename)
+        if not ext.startswith('.ini;;'):
+            filename = filename_no_ext
         else:
-            filename, _ = os.path.splitext(filename)
-            
-        return fluo_path, filename
+            filename_no_ext = filename.replace('.ini', '')
+        
+        return channel_file_path, filename_no_ext
     
     def loadPosTriggered(self):
         if not self.isDataLoaded:
@@ -30433,7 +30399,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         for p, posData in enumerate(self.data):
             # posData.ol_data = None
             for fluo_ch in fluo_channels:
-                fluo_path, filename = self.getPathFromChName(fluo_ch, posData)
+                fluo_path, filename = self.getPathAndFilenameNoExtFromChName(fluo_ch, posData)
                 if fluo_path is None:
                     self.criticalFluoChannelNotFound(fluo_ch, posData)
                     return False
@@ -30500,7 +30466,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         posData = self.data[self.pos_i]
 
         fluo_ch = self.secondChannelName
-        fluo_path, filename = self.getPathFromChName(fluo_ch, posData)
+        fluo_path, filename = self.getPathAndFilenameNoExtFromChName(fluo_ch, posData)
         if filename in posData.fluo_data_dict:
             fluo_data = posData.fluo_data_dict[filename]
         else:
@@ -31149,27 +31115,34 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.worker.abort = True
             self.waitCond.wakeAll()
             return
+        
+        parts = filename[len(posData.basename):].split(';;')
+        if len(parts) == 2:
+            channel_name = parts[1]
+        else:
+            channel_name = parts[0]
+            
         if win.useMiddleSlice:
-            user_ch_name = filename[len(posData.basename):]
             for _posData in self.data:
                 if _posData is None:
                     continue
-                _, filename = self.getPathFromChName(user_ch_name, _posData)
-                df = myutils.getDefault_SegmInfo_df(_posData, filename)
+                
+                _, _filename = self.getPathAndFilenameNoExtFromChName(channel_name, _posData)
+                printl(_filename)
+                df = myutils.getDefault_SegmInfo_df(_posData, _filename)
                 _posData.segmInfo_df = pd.concat([df, _posData.segmInfo_df])
                 unique_idx = ~_posData.segmInfo_df.index.duplicated()
                 _posData.segmInfo_df = _posData.segmInfo_df[unique_idx]
                 _posData.segmInfo_df.to_csv(_posData.segmInfo_df_csv_path)
         elif win.useSameAsCh:
-            user_ch_name = filename[len(posData.basename):]
             for _posData in self.data:
                 if _posData is None:
                     continue
-                _, srcFilename = self.getPathFromChName(
+                _, srcFilename = self.getPathAndFilenameNoExtFromChName(
                     win.selectedChannel, _posData
                 )
                 cellacdc_df = _posData.segmInfo_df.loc[srcFilename].copy()
-                _, dstFilename = self.getPathFromChName(user_ch_name, _posData)
+                _, dstFilename = self.getPathAndFilenameNoExtFromChName(channel_name, _posData)
                 if dstFilename is None:
                     self.worker.abort = True
                     self.waitCond.wakeAll()
@@ -31194,12 +31167,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 _posData.segmInfo_df.to_csv(_posData.segmInfo_df_csv_path)
         elif win.runDataPrep:
             user_ch_file_paths = []
-            user_ch_name = filename[len(self.data[self.pos_i].basename):]
             for _posData in self.data:
                 if _posData is None:
                     continue
                 user_ch_path = load.get_filename_from_channel(
-                    _posData.images_path, user_ch_name
+                    _posData.images_path, channel_name
                 )
                 if user_ch_path is None:
                     self.worker.abort = True

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -31133,7 +31133,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     continue
                 
                 _, _filename = self.getPathAndFilenameNoExtFromChName(channel_name, _posData)
-                printl(_filename)
                 df = myutils.getDefault_SegmInfo_df(_posData, _filename)
                 _posData.segmInfo_df = pd.concat([df, _posData.segmInfo_df])
                 unique_idx = ~_posData.segmInfo_df.index.duplicated()

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -940,6 +940,7 @@ def get_filename_from_channel(
     if basename is None:
         basename = ''
     
+    symlink_channel_filepath = ''
     channel_filepath = ''
     h5_aligned_path = ''
     h5_path = ''
@@ -967,7 +968,9 @@ def get_filename_from_channel(
             continue
 
         channelDataPath = os.path.join(images_path, file)
-        if file == f'{basename}{channel_name}':
+        if file.endswith('_symlink.ini'):
+            symlink_channel_filepath = f'{channelDataPath};;{channel_name}'
+        elif file == f'{basename}{channel_name}':
             channel_filepath = channelDataPath
         elif file.endswith(f'{basename}{channel_name}_aligned.h5'):
             h5_aligned_path = channelDataPath
@@ -978,7 +981,11 @@ def get_filename_from_channel(
         elif file.endswith(f'{basename}{channel_name}.tif'):
             tif_path = channelDataPath
     
-    if channel_filepath:
+    if symlink_channel_filepath:
+        if logger is not None:
+            logger(f'Using channel file ({symlink_channel_filepath})...')
+        return symlink_channel_filepath
+    elif channel_filepath:
         if logger is not None:
             logger(f'Using channel file ({channel_filepath})...')
         return channel_filepath
@@ -1001,14 +1008,31 @@ def get_filename_from_channel(
     else:
         return ''
 
+def read_img_data_from_symlink(symlink_filepath, channel_name):
+    from cellacdc.acdc_bioio_bioformats._utils import (
+        load_image_data_from_symlink
+    )
+    cp_symlink = config.ConfigParser()
+    cp_symlink.read(symlink_filepath)
+    img_data = load_image_data_from_symlink(cp_symlink, channel_name)
+    img_data = np.squeeze(img_data)
+    return img_data
+
 def imread(path):
     if path.endswith('.tif') or path.endswith('.tiff'):
         return tifffile.imread(path)
     else:
         return skimage.io.imread(path)
 
-def load_image_file(filepath):
-    if filepath.endswith('.h5'):
+def load_image_file(filepath: str | os.PathLike):
+    # The function `get_filename_from_channel` will append ';;channel_name' 
+    # when the imgPath is the symlink.ini file
+    parts = filepath.split(';;')
+    if len(parts) == 2:
+        filepath, channel_name = parts
+        if filepath.endswith('symlink.ini'):
+            img_data = read_img_data_from_symlink(filepath, channel_name)
+    elif filepath.endswith('.h5'):
         with h5py.File(filepath, 'r') as h5f:
             img_data = h5f['data'][()]
     elif filepath.endswith('.npz'):
@@ -1019,6 +1043,9 @@ def load_image_file(filepath):
         img_data = np.load(filepath)
     else:
         img_data = imread(filepath)
+    
+    printl(img_data.max())
+    
     return np.squeeze(img_data)
 
 def load_image_data_from_channel(images_path: os.PathLike, channel_name: str):
@@ -1289,7 +1316,9 @@ class loadData:
         self.bkgrROIs = []
         self.loadedFluoChannels = set()
         self.parent = QParent
-        self.imgPath = imgPath
+        # The function `get_filename_from_channel` will append ';;channel_name' 
+        # when the imgPath is the symlink.ini file
+        self.imgPath = imgPath.split(';;')[0]
         self.user_ch_name = user_ch_name
         self.images_path = os.path.dirname(imgPath)
         self.images_folder_files = os.listdir(self.images_path)
@@ -1521,15 +1550,10 @@ class loadData:
         self.z0_window = 0
         self.t0_window = 0
         if imgPath.endswith('symlink.ini'):
-            from cellacdc.acdc_bioio_bioformats._utils import (
-                load_image_data_from_symlink
+            img_data = read_img_data_from_symlink(
+                imgPath, self.user_ch_name
             )
-            cp_symlink = config.ConfigParser()
-            cp_symlink.read(imgPath)
-            img_data = load_image_data_from_symlink(
-                cp_symlink, self.user_ch_name
-            )
-            self.img_data = np.squeeze(img_data)
+            self.img_data = img_data
             self.dset = self.img_data
             self.img_data_shape = self.img_data.shape
         elif self.ext == '.h5':
@@ -4048,11 +4072,11 @@ def get_channel_names_from_symlink(symlink_ini_filepath):
     cp_symlink = config.ConfigParser()
     cp_symlink.read(symlink_ini_filepath)
     channel_names = []
-    for section in cp_symlink.sections():
-        if not section.startswith('channel_name.'):
+    for section_name in cp_symlink.sections():
+        if not section_name.startswith('channel_name.'):
             continue
         
-        channel_name = channel_names.split('.')[-1]
+        channel_name = section_name.split('.')[-1]
         channel_names.append(channel_name)
     
     return channel_names

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4044,6 +4044,19 @@ def get_tooltips_from_docs():
             tipdict[name] = f"Name: {title}\nShortcut: {shortcut}\n\n{desc}"
     return tipdict
 
+def get_channel_names_from_symlink(symlink_ini_filepath):
+    cp_symlink = config.ConfigParser()
+    cp_symlink.read(symlink_ini_filepath)
+    channel_names = []
+    for section in cp_symlink.sections():
+        if not section.startswith('channel_name.'):
+            continue
+        
+        channel_name = channel_names.split('.')[-1]
+        channel_names.append(channel_name)
+    
+    return channel_names
+
 def save_df_to_csv_temp_path(df, csv_filename, **to_csv_kwargs):
     tempDir = tempfile.mkdtemp()
     tempFilepath = os.path.join(tempDir, csv_filename)

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -651,7 +651,9 @@ def load_acdc_df_file(
         return acdc_df
 
 def save_acdc_df_file(
-        acdc_df, csv_path, custom_annot_columns=None, 
+        acdc_df: pd.DataFrame, 
+        csv_path: os.PathLike, 
+        custom_annot_columns=None, 
         last_cca_frame_i=None
     ):
     if custom_annot_columns is not None:
@@ -675,6 +677,13 @@ def save_acdc_df_file(
         max_frame_i = acdc_df.index.get_level_values('frame_i').max()
         if last_cca_frame_i < max_frame_i:
             acdc_df.loc[last_cca_frame_i+1:, cca_df_colnames] = pd.NA
+    
+    try:
+        images_path = os.path.dirname(csv_path)
+        basename = get_basename(images_path)
+        acdc_df.insert(0, 'basename', basename)
+    except Exception as err:
+        pass
     
     try:
         acdc_df.to_csv(csv_path)
@@ -1511,7 +1520,19 @@ class loadData:
             imgPath = self.imgPath
         self.z0_window = 0
         self.t0_window = 0
-        if self.ext == '.h5':
+        if imgPath.endswith('symlink.ini'):
+            from cellacdc.acdc_bioio_bioformats._utils import (
+                load_image_data_from_symlink
+            )
+            cp_symlink = config.ConfigParser()
+            cp_symlink.read(imgPath)
+            img_data = load_image_data_from_symlink(
+                cp_symlink, self.user_ch_name
+            )
+            self.img_data = np.squeeze(img_data)
+            self.dset = self.img_data
+            self.img_data_shape = self.img_data.shape
+        elif self.ext == '.h5':
             self.h5f = h5py.File(imgPath, 'r')
             self.dset = self.h5f['data']
             self.img_data_shape = self.dset.shape
@@ -1545,7 +1566,6 @@ class loadData:
                 self.img_data = np.squeeze(self.dset[:self.loadSizeT])
             elif is2D:
                 self.img_data = np.squeeze(self.dset[:])
-
         elif self.ext == '.npz':
             self.img_data = np.squeeze(np.load(imgPath)['arr_0'])
             self.dset = self.img_data
@@ -4102,6 +4122,13 @@ def search_filepath_in_pos_path_from_endname(
     for file in images_files:
         if file == to_match:
             return os.path.join(images_path, file)
+
+def get_basename(images_path):
+    images_files = myutils.listdir(images_path)
+    sample_filepath = os.path.join(images_path, images_files[0])
+    posData = loadData(sample_filepath, '')
+    posData.getBasenameAndChNames()
+    return posData.basename
 
 def search_filepath_from_endname(exp_path, endname, include_spotmax_out=False):
     pos_foldernames = myutils.get_pos_foldernames(exp_path)

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -683,7 +683,6 @@ def save_acdc_df_file(
     try:
         images_path = os.path.dirname(csv_path)
         basename = get_basename(images_path)
-        acdc_df.insert(0, 'basename', basename)
         if 'basename' in acdc_df.columns:
             acdc_df['basename'] = basename
         else:
@@ -4212,18 +4211,12 @@ def search_filepath_in_pos_path_from_endname(
             return os.path.join(images_path, file)
 
 def get_basename(images_path):
-    images_files = myutils.listdir(images_path)
-    sample_filepath = os.path.join(images_path, images_files[0])
-    posData = loadData(sample_filepath, '')
-    posData.getBasenameAndChNames()
-    return posData.basename
+    basename, _ = myutils.getBasenameAndChNames(images_path)
+    return basename
 
 def get_channel_names(images_path):
-    images_files = myutils.listdir(images_path)
-    sample_filepath = os.path.join(images_path, images_files[0])
-    posData = loadData(sample_filepath, '')
-    posData.getBasenameAndChNames()
-    return posData.chNames
+    _, chNames = myutils.getBasenameAndChNames(images_path)
+    return chNames
 
 def search_filepath_from_endname(exp_path, endname, include_spotmax_out=False):
     pos_foldernames = myutils.get_pos_foldernames(exp_path)
@@ -4362,9 +4355,9 @@ def save_symlink_ini_from_image_filepath(
     frames_range_str = ','.join(map(str, frames_range))
     
     if zslices_range is None:
-        zslices_range = (0,1)
+        zslices_range = (0, 1)
     
-    zslices_range_str = ','.join(zslices_range)
+    zslices_range_str = ','.join(map(str, zslices_range))
     
     use_bioio = 'False' if ext in ACDC_IMAGE_EXTENSIONS else 'True'
     cp_symlink[f'channel_name.{channel_name}'] = {

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4317,7 +4317,7 @@ def save_symlink_ini_from_image_filepath(
     symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
     symlink_ini_filepath = os.path.join(images_folderpath, symlink_ini_filename)
     cp_symlink = config.ConfigParser()
-    use_bioio = 'True' if ext in ACDC_IMAGE_EXTENSIONS else 'False'
+    use_bioio = 'False' if ext in ACDC_IMAGE_EXTENSIONS else 'True'
     cp_symlink[f'channel_name.{channel_name}'] = {
         'source_filepath': image_filepath,
         'frames_range': '0,1',

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4357,9 +4357,9 @@ def save_symlink_ini_from_image_filepath(
         cp_symlink.read(symlink_ini_filepath)
     
     if frames_range is None:
-        frames_range = (0,1)
+        frames_range = (0, 1)
     
-    frames_range_str = ','.join(frames_range)
+    frames_range_str = ','.join(map(str, frames_range))
     
     if zslices_range is None:
         zslices_range = (0,1)

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4347,7 +4347,8 @@ def save_symlink_ini_from_image_filepath(
     if not basename:
         symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
     else:
-        symlink_ini_filename = f'{basename}symlink.ini'
+        separator = '' if basename.endswith('_') else '_'
+        symlink_ini_filename = f'{basename}{separator}symlink.ini'
     symlink_ini_filepath = os.path.join(images_folderpath, symlink_ini_filename)
     cp_symlink = config.ConfigParser()
     if os.path.exists(symlink_ini_filepath):

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -997,13 +997,18 @@ def get_filename_from_channel(
         return ''
 
 def read_img_data_from_symlink(symlink_filepath, channel_name):
-    from cellacdc.acdc_bioio_bioformats._utils import (
-        load_image_data_from_symlink
-    )
     cp_symlink = config.ConfigParser()
     cp_symlink.read(symlink_filepath)
-    img_data = load_image_data_from_symlink(cp_symlink, channel_name)
-    img_data = np.squeeze(img_data)
+    channel_section = f'channel_name.{channel_name}'
+    if cp_symlink[channel_section].getboolean('use_bioio', True):
+        from cellacdc.acdc_bioio_bioformats._utils import (
+            load_image_data_from_symlink as bioio_load_image_data_from_symlink
+        )
+        
+        img_data = bioio_load_image_data_from_symlink(cp_symlink, channel_name)
+        img_data = np.squeeze(img_data)
+    else:
+        img_data = load_image_data_from_symlink(cp_symlink, channel_name)
     return img_data
 
 def imread(path):
@@ -4271,3 +4276,51 @@ def load_image_and_bkgr_data(image_filepath: os.PathLike):
         return None, None
 
     return img_data, bkgrData
+
+def save_symlink_ini_from_image_filepath(
+        image_filepath: os.PathLike,
+        images_folderpath: os.PathLike,
+        channel_name: str 
+    ):
+    filename = os.path.basename(image_filepath)
+    filename_no_ext, ext = os.path.splitext(filename)
+    symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
+    symlink_ini_filepath = os.path.join(images_folderpath, symlink_ini_filename)
+    cp_symlink = config.ConfigParser()
+    cp_symlink[f'channel_name.{channel_name}'] = {
+        'source_filepath': image_filepath,
+        'frames_range': '0,1',
+        'zslices_range': '0,1',
+        'channel_index': '0',
+        'series_index': '0',
+        'lazy_load': 'False',
+        'use_bioio': 'False',
+    }
+    with open(symlink_ini_filepath, 'w') as configfile:
+        cp_symlink.write(configfile)
+
+def load_image_data_from_symlink(
+        cp_symlink: config.ConfigParser,
+        channel_name: str, 
+    ):
+    section_name = f'channel_name.{channel_name}'
+    section = cp_symlink[section_name]
+    source_filepath = section['source_filepath']
+    img_data = load_image_file(source_filepath)
+    is_rgb = (
+        img_data.ndim == 3 and img_data.shape[-1] == 3
+    )
+    is_rgba = (
+        img_data.ndim == 4 and img_data.shape[-1] == 4
+    )
+    
+    if not is_rgb and not is_rgba:
+        return img_data
+    
+    if is_rgb:
+        img_data = skimage.color.rgb2gray(img_data)
+    else:
+        img_data = cv2.cvtColor(img_data, cv2.COLOR_RGBA2GRAY)
+    
+    img_data = skimage.img_as_ubyte(img_data)
+    return img_data

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -839,20 +839,8 @@ def read_acdc_df_from_archive(archive_path, key):
 def get_user_ch_paths(images_paths, user_ch_name):
     user_ch_file_paths = []
     for images_path in images_paths:
-        img_aligned_found = False
-        for filename in myutils.listdir(images_path):
-            if filename.find(f'{user_ch_name}_aligned.np') != -1:
-                img_path_aligned = f'{images_path}/{filename}'
-                img_aligned_found = True
-            elif filename.find(f'{user_ch_name}.tif') != -1:
-                img_path_tif = f'{images_path}/{filename}'
-
-        if img_aligned_found:
-            img_path = img_path_aligned
-        else:
-            img_path = img_path_tif
+        img_path = get_filename_from_channel(images_path, user_ch_name)
         user_ch_file_paths.append(img_path)
-        print(f'Loading {img_path}...')
     return user_ch_file_paths
 
 def get_acdc_output_files(images_path):
@@ -1044,8 +1032,6 @@ def load_image_file(filepath: str | os.PathLike):
     else:
         img_data = imread(filepath)
     
-    printl(img_data.max())
-    
     return np.squeeze(img_data)
 
 def load_image_data_from_channel(images_path: os.PathLike, channel_name: str):
@@ -1113,7 +1099,6 @@ def get_endname_from_filepath(filepath, allow_empty=False):
     
     return endname
     
-
 def get_endnames_from_basename(basename, filenames):
     return [os.path.splitext(f)[0][len(basename):] for f in filenames]
 
@@ -1338,8 +1323,13 @@ class loadData:
         path_li = os.path.normpath(imgPath).split(os.sep)
         self.relPath = f'{f"{os.sep}".join(path_li[-relPathDepth:])}'
         filename_ext = os.path.basename(imgPath)
+        filename, ext = os.path.splitext(filename_ext)
+        if ext.startswith('.ini;;') and ';;' not in filename:
+            # This is needed to make the filename unique to the channel, 
+            # since the symlink.ini file is shared for all channels
+            filename = f'{filename};;{user_ch_name}'
         self.filename_ext = filename_ext
-        self.filename, self.ext = os.path.splitext(filename_ext)
+        self.filename, self.ext = filename, ext
         self._additionalMetadataValues = None
         self.loadLastEntriesMetadata()
         self.attempFixBasenameBug()
@@ -1417,6 +1407,10 @@ class loadData:
             if chName.endswith('_aligned'):
                 aligned_idx = chName.find('_aligned')
                 chName = chName[:aligned_idx]
+            
+            if ';;' in chName:
+                chName = chName.split(';;')[-1]
+            
             loadedChNames.append(chName)
 
         if returnList:
@@ -4237,3 +4231,43 @@ def read_measurements_workflow_from_config(filepath):
             
             ini_items[section][option] = value
     return ini_items
+
+def load_image_and_bkgr_data(image_filepath: os.PathLike):
+    images_path = os.path.dirname(image_filepath)
+    bkgrData = None
+    # Load overlay frames and align if needed
+    filename = os.path.basename(image_filepath)
+    filename_noEXT, ext = os.path.splitext(filename)
+    img_data = load_image_file(image_filepath)
+    if ext == '.npy' or ext == '.npz':
+        # Load background data
+        bkgrData_path = os.path.join(
+            images_path, f'{filename_noEXT}_bkgrRoiData.npz'
+        )
+        if os.path.exists(bkgrData_path):
+            bkgrData = np.load(bkgrData_path)
+    elif ext == '.tif' or ext == '.tiff':
+        aligned_filename = f'{filename_noEXT}_aligned.npz'
+        aligned_path = os.path.join(images_path, aligned_filename)
+        if os.path.exists(aligned_path):
+            # Load background data
+            bkgrData_path = os.path.join(
+                images_path, f'{aligned_filename}_bkgrRoiData.npz'
+            )
+            if os.path.exists(bkgrData_path):
+                bkgrData = np.load(bkgrData_path)
+        else:
+            # Load background data
+            bkgrData_path = os.path.join(
+                images_path, f'{filename_noEXT}_bkgrRoiData.npz'
+            )
+            if os.path.exists(bkgrData_path):
+                bkgrData = np.load(bkgrData_path)
+    elif ext.startswith('.ini;;'):
+        # If the file is .ini, it's a raw file that was not cropped, 
+        # hence `_bkgrRoiData.npz` file does not exist.
+        pass
+    else:
+        return None, None
+
+    return img_data, bkgrData

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -964,7 +964,8 @@ def get_filename_from_channel(
         if file.endswith('_symlink.ini'):
             cp_symlink = config.ConfigParser()
             cp_symlink.read(filepath)
-            if channel_name in cp_symlink.sections():
+            channel_section = f'channel_name.{channel_name}'
+            if channel_section in cp_symlink.sections():
                 symlink_channel_filepath = f'{filepath};;{channel_name}'
                 
         if file == f'{basename}{channel_name}':
@@ -979,12 +980,7 @@ def get_filename_from_channel(
             tif_path = filepath
     
     if symlink_channel_filepath:
-        cp_symlink = config.ConfigParser()
-        cp_symlink.read(symlink_channel_filepath)
-        if channel_name in cp_symlink.sections():
-            if logger is not None:
-                logger(f'Using channel file ({symlink_channel_filepath})...')
-            return symlink_channel_filepath
+        return symlink_channel_filepath
     
     if channel_filepath:
         if logger is not None:
@@ -1026,7 +1022,10 @@ def read_img_data_from_symlink(symlink_filepath, channel_name):
         img_data = bioio_load_image_data_from_symlink(cp_symlink, channel_name)
         img_data = np.squeeze(img_data)
     else:
-        img_data = load_image_data_from_symlink(cp_symlink, channel_name)
+        img_data = load_image_data_from_symlink(
+            cp_symlink=cp_symlink, 
+            channel_name=channel_name
+        )
     return img_data
 
 def imread(path):
@@ -4316,11 +4315,18 @@ def save_symlink_ini_from_image_filepath(
     }
     with open(symlink_ini_filepath, 'w') as configfile:
         cp_symlink.write(configfile)
+    
+    return symlink_ini_filepath
 
 def load_image_data_from_symlink(
-        cp_symlink: config.ConfigParser,
-        channel_name: str, 
+        cp_symlink: config.ConfigParser=None,
+        channel_name: str='', 
+        cp_symlink_filepath: os.PathLike=None
     ):
+    if cp_symlink_filepath is not None:
+        cp_symlink = config.ConfigParser()
+        cp_symlink.read(cp_symlink_filepath)
+
     section_name = f'channel_name.{channel_name}'
     section = cp_symlink[section_name]
     source_filepath = section['source_filepath']
@@ -4329,7 +4335,7 @@ def load_image_data_from_symlink(
         img_data.ndim == 3 and img_data.shape[-1] == 3
     )
     is_rgba = (
-        img_data.ndim == 4 and img_data.shape[-1] == 4
+        img_data.ndim == 3 and img_data.shape[-1] == 4
     )
     
     if not is_rgb and not is_rgba:

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -840,6 +840,11 @@ def get_user_ch_paths(images_paths, user_ch_name):
     user_ch_file_paths = []
     for images_path in images_paths:
         img_path = get_filename_from_channel(images_path, user_ch_name)
+        if not img_path:
+            raise FileNotFoundError(
+                f'Could not find a file for channel "{user_ch_name}" '
+                f'in images path "{images_path}".'
+            )
         user_ch_file_paths.append(img_path)
     return user_ch_file_paths
 
@@ -955,46 +960,59 @@ def get_filename_from_channel(
         if is_channel_to_skip:
             continue
 
-        channelDataPath = os.path.join(images_path, file)
+        filepath = os.path.join(images_path, file)
         if file.endswith('_symlink.ini'):
-            symlink_channel_filepath = f'{channelDataPath};;{channel_name}'
-        elif file == f'{basename}{channel_name}':
-            channel_filepath = channelDataPath
+            cp_symlink = config.ConfigParser()
+            cp_symlink.read(filepath)
+            if channel_name in cp_symlink.sections():
+                symlink_channel_filepath = f'{filepath};;{channel_name}'
+                
+        if file == f'{basename}{channel_name}':
+            channel_filepath = filepath
         elif file.endswith(f'{basename}{channel_name}_aligned.h5'):
-            h5_aligned_path = channelDataPath
+            h5_aligned_path = filepath
         elif file.endswith(f'{basename}{channel_name}.h5'):
-            h5_path = channelDataPath
+            h5_path = filepath
         elif file.endswith(f'{basename}{channel_name}_aligned.npz'):
-            npz_aligned_path = channelDataPath
+            npz_aligned_path = filepath
         elif file.endswith(f'{basename}{channel_name}.tif'):
-            tif_path = channelDataPath
+            tif_path = filepath
     
     if symlink_channel_filepath:
-        if logger is not None:
-            logger(f'Using channel file ({symlink_channel_filepath})...')
-        return symlink_channel_filepath
-    elif channel_filepath:
+        cp_symlink = config.ConfigParser()
+        cp_symlink.read(symlink_channel_filepath)
+        if channel_name in cp_symlink.sections():
+            if logger is not None:
+                logger(f'Using channel file ({symlink_channel_filepath})...')
+            return symlink_channel_filepath
+    
+    if channel_filepath:
         if logger is not None:
             logger(f'Using channel file ({channel_filepath})...')
         return channel_filepath
-    elif h5_aligned_path:
+    
+    
+    if h5_aligned_path:
         if logger is not None:
             logger(f'Using .h5 aligned file ({h5_aligned_path})...')
         return h5_aligned_path
-    elif h5_path:
+    
+    if h5_path:
         if logger is not None:
             logger(f'Using .h5 file ({h5_path})...')
         return h5_path
-    elif npz_aligned_path:
+    
+    if npz_aligned_path:
         if logger is not None:
             logger(f'Using .npz aligned file ({npz_aligned_path})...')
         return npz_aligned_path
-    elif tif_path:
+    
+    if tif_path:
         if logger is not None:
             logger(f'Using .tif file ({tif_path})...')
         return tif_path
-    else:
-        return ''
+
+    return ''
 
 def read_img_data_from_symlink(symlink_filepath, channel_name):
     cp_symlink = config.ConfigParser()

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4340,7 +4340,9 @@ def save_symlink_ini_from_image_filepath(
         image_filepath: os.PathLike,
         images_folderpath: os.PathLike,
         channel_name: str,
-        basename: str=''
+        basename: str='',
+        frames_range: tuple[int] | None=None,
+        zslices_range: tuple[int] | None=None,
     ):
     filename = os.path.basename(image_filepath)
     filename_no_ext, ext = os.path.splitext(filename)
@@ -4353,12 +4355,22 @@ def save_symlink_ini_from_image_filepath(
     cp_symlink = config.ConfigParser()
     if os.path.exists(symlink_ini_filepath):
         cp_symlink.read(symlink_ini_filepath)
-        
+    
+    if frames_range is None:
+        frames_range = (0,1)
+    
+    frames_range_str = ','.join(frames_range)
+    
+    if zslices_range is None:
+        zslices_range = (0,1)
+    
+    zslices_range_str = ','.join(zslices_range)
+    
     use_bioio = 'False' if ext in ACDC_IMAGE_EXTENSIONS else 'True'
     cp_symlink[f'channel_name.{channel_name}'] = {
         'source_filepath': image_filepath,
-        'frames_range': '0,1',
-        'zslices_range': '0,1',
+        'frames_range': frames_range_str,
+        'zslices_range': zslices_range_str,
         'channel_index': '0',
         'series_index': '0',
         'lazy_load': 'False',
@@ -4383,7 +4395,6 @@ def create_symlinked_pos_folder(
     
     basename = get_basename(src_images_path)
     channel_names = get_channel_names(src_images_path)
-    symlink_ini_filename = f'{basename}symlink.ini'
     for file in myutils.listdir(src_images_path):
         filepath = os.path.join(src_images_path, file)
         dst_filepath = os.path.join(dst_images_path, file)

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -1042,6 +1042,7 @@ def imread(path):
 def load_image_file(filepath: str | os.PathLike):
     # The function `get_filename_from_channel` will append ';;channel_name' 
     # when the imgPath is the symlink.ini file
+    filepath = os.fspath(filepath)
     parts = filepath.split(';;')
     if len(parts) == 2:
         filepath, channel_name = parts

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -21,6 +21,8 @@ import zipfile
 from natsort import natsorted
 import time
 
+from functools import partial
+
 import skimage
 import skimage.io
 import skimage.measure    
@@ -3510,15 +3512,25 @@ class select_exp_folder:
     def __init__(self):
         self.exp_path = None
 
+    def doNotAskAgainCallback(self, selectWindow):
+        self.doNotAskAgain = True
+        selectWindow.setAllSelected(True)
+        selectWindow.cancel = False
+        selectWindow.close()
+    
     def QtPrompt(
             self, parentQWidget, values,
             current=0, title='Select Position folder',
             CbLabel="Select folder to load:",
-            showinexplorer_button=False, full_paths=None,
-            allow_cancel=True, show=False, toggleMulti=False,
+            showinexplorer_button=False, 
+            full_paths=None,
+            allow_cancel=True, 
+            show=False, 
+            toggleMulti=False,
             allowMultiSelection=True, 
             informativeText='',
-            selectedValues=None
+            selectedValues=None,
+            addDoNotAskAgain=False
         ):
         from . import apps
         font = QtGui.QFont()
@@ -3529,6 +3541,16 @@ class select_exp_folder:
             showInFileManagerPath=self.exp_path
         )
         win.setFont(font)
+        self.doNotAskAgain = False
+        if addDoNotAskAgain:
+            doNotAskAgainButton = widgets.SkipPushButton(
+                'Select all Positions for next experiment folders'
+            )
+            win.buttonsLayout.insertWidget(3, doNotAskAgainButton)
+            doNotAskAgainButton.clicked.connect(
+                partial(self.doNotAskAgainCallback, selectWindow=win)
+            )
+        
         toFront = win.windowState() & ~Qt.WindowMinimized | Qt.WindowActive
         win.setWindowState(toFront)
         win.activateWindow()
@@ -4196,6 +4218,13 @@ def get_basename(images_path):
     posData.getBasenameAndChNames()
     return posData.basename
 
+def get_channel_names(images_path):
+    images_files = myutils.listdir(images_path)
+    sample_filepath = os.path.join(images_path, images_files[0])
+    posData = loadData(sample_filepath, '')
+    posData.getBasenameAndChNames()
+    return posData.chNames
+
 def search_filepath_from_endname(exp_path, endname, include_spotmax_out=False):
     pos_foldernames = myutils.get_pos_foldernames(exp_path)
     for pos in pos_foldernames:
@@ -4310,13 +4339,20 @@ def load_image_and_bkgr_data(image_filepath: os.PathLike):
 def save_symlink_ini_from_image_filepath(
         image_filepath: os.PathLike,
         images_folderpath: os.PathLike,
-        channel_name: str 
+        channel_name: str,
+        basename: str=''
     ):
     filename = os.path.basename(image_filepath)
     filename_no_ext, ext = os.path.splitext(filename)
-    symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
+    if not basename:
+        symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
+    else:
+        symlink_ini_filename = f'{basename}symlink.ini'
     symlink_ini_filepath = os.path.join(images_folderpath, symlink_ini_filename)
     cp_symlink = config.ConfigParser()
+    if os.path.exists(symlink_ini_filepath):
+        cp_symlink.read(symlink_ini_filepath)
+        
     use_bioio = 'False' if ext in ACDC_IMAGE_EXTENSIONS else 'True'
     cp_symlink[f'channel_name.{channel_name}'] = {
         'source_filepath': image_filepath,
@@ -4331,6 +4367,57 @@ def save_symlink_ini_from_image_filepath(
         cp_symlink.write(configfile)
     
     return symlink_ini_filepath
+
+def create_symlinked_pos_folder(
+        src_pos_folderpath: os.PathLike,
+        dst_pos_folderpath: os.PathLike,
+        segm_endanmes_to_copy: None | list[str]=None
+    ):
+    if segm_endanmes_to_copy is None:
+        segm_endanmes_to_copy = []
+    
+    src_images_path = os.path.join(src_pos_folderpath, 'Images')
+    dst_images_path = os.path.join(dst_pos_folderpath, 'Images')
+    os.makedirs(dst_images_path, exist_ok=True)
+    
+    basename = get_basename(src_images_path)
+    channel_names = get_channel_names(src_images_path)
+    symlink_ini_filename = f'{basename}symlink.ini'
+    for file in myutils.listdir(src_images_path):
+        filepath = os.path.join(src_images_path, file)
+        dst_filepath = os.path.join(dst_images_path, file)
+        for channel in channel_names:
+            if file == f'{basename}{channel}.tif':
+                save_symlink_ini_from_image_filepath(
+                    filepath, dst_images_path, channel, 
+                    basename=basename
+                )
+            
+            elif file == f'{basename}{channel}.h5':
+                save_symlink_ini_from_image_filepath(
+                    filepath, dst_images_path, channel,
+                    basename=basename
+                )
+        
+        if file.endswith('metadata.csv'):
+            shutil.copy2(filepath, dst_filepath)
+        elif file.endswith('metadataXML.txt'):
+            shutil.copy2(filepath, dst_filepath)
+        
+        if not segm_endanmes_to_copy:
+            continue
+        
+        if file.endswith('segm_hyperparams.ini'):
+            shutil.copy2(filepath, dst_filepath)
+        elif file.endswith('segmInfo.csv'):
+            shutil.copy2(filepath, dst_filepath)
+        
+        for segm_endname in segm_endanmes_to_copy:
+            acdc_output_endname = segm_endname.replace('segm', 'acdc_output')
+            if file == f'{basename}{segm_endname}.npz':
+                shutil.copy2(filepath, dst_filepath)
+            if file == f'{basename}{acdc_output_endname}.csv':
+                shutil.copy2(filepath, dst_filepath)
 
 def load_image_data_from_symlink(
         cp_symlink: config.ConfigParser=None,

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4392,6 +4392,10 @@ def create_symlinked_pos_folder(
     for file in myutils.listdir(src_images_path):
         filepath = os.path.join(src_images_path, file)
         dst_filepath = os.path.join(dst_images_path, file)
+        if file.endswith('_symlink.ini'):
+            shutil.copy2(filepath, dst_filepath)
+            continue
+        
         for channel in channel_names:
             if file == f'{basename}{channel}.tif':
                 save_symlink_ini_from_image_filepath(

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4397,15 +4397,16 @@ def create_symlinked_pos_folder(
             continue
         
         for channel in channel_names:
-            if file == f'{basename}{channel}.tif':
+            valid_image_files = (
+                f'{basename}{channel}.tif',
+                f'{basename}{channel}.tiff',
+                f'{basename}{channel}.h5',
+                f'{basename}_{channel}_aligned.npz',
+                f'{basename}_{channel}_aligned.npz',
+            )
+            if file in valid_image_files:
                 save_symlink_ini_from_image_filepath(
                     filepath, dst_images_path, channel, 
-                    basename=basename
-                )
-            
-            elif file == f'{basename}{channel}.h5':
-                save_symlink_ini_from_image_filepath(
-                    filepath, dst_images_path, channel,
                     basename=basename
                 )
         

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -39,7 +39,7 @@ from . import cca_functions
 from . import sorted_cols
 from . import io
 from . import core
-from . import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
+from . import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, ACDC_IMAGE_EXTENSIONS
 
 from . import GUI_INSTALLED
 
@@ -682,8 +682,12 @@ def save_acdc_df_file(
         images_path = os.path.dirname(csv_path)
         basename = get_basename(images_path)
         acdc_df.insert(0, 'basename', basename)
+        if 'basename' in acdc_df.columns:
+            acdc_df['basename'] = basename
+        else:
+            acdc_df.insert(0, 'basename', basename)
     except Exception as err:
-        pass
+        printl(f'[WARNING]: Failed to set basename column for "{csv_path}": {err}')
     
     try:
         acdc_df.to_csv(csv_path)
@@ -1042,6 +1046,15 @@ def load_image_file(filepath: str | os.PathLike):
         filepath, channel_name = parts
         if filepath.endswith('symlink.ini'):
             img_data = read_img_data_from_symlink(filepath, channel_name)
+        else:
+            raise ValueError(
+                "Malformed image filepath with ';;channel_name' suffix: "
+                f"{filepath} does not point to a symlink.ini file."
+            )
+    elif len(parts) > 2:
+        raise ValueError(
+            f"Malformed image filepath: expected at most one ';;' separator, got {filepath!r}"
+        )
     elif filepath.endswith('.h5'):
         with h5py.File(filepath, 'r') as h5f:
             img_data = h5f['data'][()]
@@ -4304,6 +4317,7 @@ def save_symlink_ini_from_image_filepath(
     symlink_ini_filename = f'{filename_no_ext}_symlink.ini'
     symlink_ini_filepath = os.path.join(images_folderpath, symlink_ini_filename)
     cp_symlink = config.ConfigParser()
+    use_bioio = 'True' if ext in ACDC_IMAGE_EXTENSIONS else 'False'
     cp_symlink[f'channel_name.{channel_name}'] = {
         'source_filepath': image_filepath,
         'frames_range': '0,1',
@@ -4311,7 +4325,7 @@ def save_symlink_ini_from_image_filepath(
         'channel_index': '0',
         'series_index': '0',
         'lazy_load': 'False',
-        'use_bioio': 'False',
+        'use_bioio': use_bioio,
     }
     with open(symlink_ini_filepath, 'w') as configfile:
         cp_symlink.write(configfile)

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -373,12 +373,15 @@ class Logger(logging.Logger):
             self._stdout.write(text)
         
         if self._q_log_widget is not None:
-            self._q_log_widget.appendPlainText(text)
             try:
-                self._q_log_widget.verticalScrollBar().setValue(
-                    self._q_log_widget.verticalScrollBar().maximum()
-                )
-            except Exception as err:
+                # Log thread-safely to the QPlainTextEdit widget
+                from qtpy.QtCore import QThread
+                if QThread.currentThread() == self._q_log_widget.thread():
+                    self._q_log_widget.appendPlainText(text)
+                    self._q_log_widget.verticalScrollBar().setValue(
+                        self._q_log_widget.verticalScrollBar().maximum()
+                    )
+            except Exception:
                 pass
         
         if not log_to_file:

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -58,7 +58,7 @@ from . import settings_folderpath
 from .models._cellpose_base import min_target_versions_cp
 
 if GUI_INSTALLED:
-    from qtpy.QtWidgets import QMessageBox
+    from qtpy.QtWidgets import QMessageBox, QPlainTextEdit
     from qtpy.QtCore import Signal, QObject, QCoreApplication
     
     from . import widgets, apps
@@ -341,7 +341,8 @@ class Logger(logging.Logger):
             self,
             module='base', 
             name='cellacdc-logger', 
-            level=logging.DEBUG
+            level=logging.DEBUG,
+            QLogWidget: 'QPlainTextEdit'=None
         ):
         super().__init__(f'{name}-{module}', level=level)
         self._stdout = sys.stdout
@@ -355,6 +356,7 @@ class Logger(logging.Logger):
             10: "DEBUG",
             0: "NOTSET"
         }
+        self._q_log_widget = QLogWidget
         
     def write(self, text, log_to_file=True, write_to_stdout=True):
         """Capture print statements, print to terminal and log text to 
@@ -369,7 +371,16 @@ class Logger(logging.Logger):
         """     
         if write_to_stdout:   
             self._stdout.write(text)
-            
+        
+        if self._q_log_widget is not None:
+            self._q_log_widget.appendPlainText(text)
+            try:
+                self._q_log_widget.verticalScrollBar().setValue(
+                    self._q_log_widget.verticalScrollBar().maximum()
+                )
+            except Exception as err:
+                pass
+        
         if not log_to_file:
             return
         
@@ -598,11 +609,16 @@ def _log_system_info(logger, log_path, is_cli=False, also_spotmax=False):
     smax_info_txt = smax_info(include_platform=False)
     logger.info(smax_info_txt)
 
-def setupLogger(module='base', logs_path=None, caller='Cell-ACDC'):
+def setupLogger(
+        module='base', 
+        logs_path=None, 
+        caller='Cell-ACDC', 
+        QLogWidget=None
+    ):
     if logs_path is None:
         logs_path = get_logs_path()
     
-    logger = Logger(module=module)
+    logger = Logger(module=module, QLogWidget=QLogWidget)
     sys.stdout = logger
     
     delete_older_log_files(logs_path)

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -1075,26 +1075,8 @@ def getAcdcDfSegmPaths(images_path):
     return paths
 
 def getChannelFilePath(images_path, chName):
-    file = ''
-    alignedFilePath = ''
-    tifFilePath = ''
-    h5FilePath = ''
-    for file in listdir(images_path):
-        filePath = os.path.join(images_path, file)
-        if file.endswith(f'{chName}_aligned.npz'):
-            alignedFilePath = filePath
-        elif file.endswith(f'{chName}.tif'):
-            tifFilePath = filePath
-        elif file.endswith(f'{chName}.h5'):
-            h5FilePath = filePath
-    if alignedFilePath:
-        return alignedFilePath
-    elif h5FilePath:
-        return h5FilePath
-    elif tifFilePath:
-        return tifFilePath
-    else:
-        return ''
+    channel_filepath = load.get_filename_from_channel(images_path, chName)
+    return channel_filepath
 
 def get_number_fstring_formatter(dtype, precision=4):
     if np.issubdtype(dtype, np.integer):
@@ -1109,6 +1091,10 @@ def get_chname_from_basename(filename, basename, remove_ext=True):
     aligned_idx = chName.find('_aligned')
     if aligned_idx != -1:
         chName = chName[:aligned_idx]
+    
+    if chName.startswith('symlink.ini;;'):
+        chName = chName.split(';;')[1]
+        
     return chName
 
 def getBaseAcdcDf(rp):

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -1092,8 +1092,8 @@ def get_chname_from_basename(filename, basename, remove_ext=True):
     if aligned_idx != -1:
         chName = chName[:aligned_idx]
     
-    if chName.startswith('symlink.ini;;'):
-        chName = chName.split(';;')[1]
+    if ';;' in chName:
+        chName = chName.split(';;')[-1]
         
     return chName
 

--- a/cellacdc/prompts.py
+++ b/cellacdc/prompts.py
@@ -117,6 +117,14 @@ class select_channel_name:
             if channel_names:
                 return channel_names, False
         
+        # Next, check if there is the symlink.ini file
+        for file in myutils.listdir(images_path):
+            if file.endswith('_symlink.ini'):
+                channel_names = load.get_channel_names_from_symlink(
+                    os.path.join(images_path, file)
+                )
+                return channel_names, False
+        
         # Find basename as intersection of filenames
         channel_names = set()
         self.basenameNotFound = False

--- a/cellacdc/prompts.py
+++ b/cellacdc/prompts.py
@@ -160,9 +160,8 @@ class select_channel_name:
             basename = file[i:i+k]
         self.basename = basename
         
-        if channel_names is not None:
+        if channel_names:
             return channel_names, False
-        
         channel_names = set()
         basenameNotFound = [False]
         for file in filenames:

--- a/cellacdc/prompts.py
+++ b/cellacdc/prompts.py
@@ -29,6 +29,7 @@ class select_channel_name:
         self.last_sel_channel = self._load_last_selection()
         self.was_aborted = False
         self.allow_abort = allow_abort
+        self.basename = None
 
     def _get_available_channels_from_metadata(
             self, metadata_csv_path, filenames, channelExt
@@ -108,7 +109,7 @@ class select_channel_name:
                 break
         
         chNames_found = False
-        channel_names = set()
+        channel_names = None
         basename = None
         if metadata_csv_path is not None:
             channel_names = self._get_available_channels_from_metadata(
@@ -123,10 +124,10 @@ class select_channel_name:
                 channel_names = load.get_channel_names_from_symlink(
                     os.path.join(images_path, file)
                 )
-                return channel_names, False
+                if self.basename is not None:
+                    return channel_names, False
         
         # Find basename as intersection of filenames
-        channel_names = set()
         self.basenameNotFound = False
         isBasenamePresent = myutils.checkDataIntegrity(filenames, images_path)
         if basename is None:
@@ -156,6 +157,10 @@ class select_channel_name:
             basename = file[i:i+k]
         self.basename = basename
         
+        if channel_names is not None:
+            return channel_names, False
+        
+        channel_names = set()
         basenameNotFound = [False]
         for file in filenames:
             if file.endswith('edited.h5'):

--- a/cellacdc/prompts.py
+++ b/cellacdc/prompts.py
@@ -162,6 +162,7 @@ class select_channel_name:
         
         if channel_names:
             return channel_names, False
+        
         channel_names = set()
         basenameNotFound = [False]
         for file in filenames:

--- a/cellacdc/prompts.py
+++ b/cellacdc/prompts.py
@@ -124,7 +124,10 @@ class select_channel_name:
                 channel_names = load.get_channel_names_from_symlink(
                     os.path.join(images_path, file)
                 )
-                if self.basename is not None:
+                if channel_names:
+                    basename = file[:-len('_symlink.ini')]
+                    self.basename = basename
+                    self.basenameNotFound = False
                     return channel_names, False
         
         # Find basename as intersection of filenames

--- a/cellacdc/segm.py
+++ b/cellacdc/segm.py
@@ -396,58 +396,32 @@ class segmWin(QMainWindow):
                 self.criticalImagesFolderEmpty(images_path)
                 self.close()
                 return
-            if ch_name_selector.is_first_call:
-                ch_names, warn = (
-                    ch_name_selector.get_available_channels(
-                        filenames, images_path
-                ))
-                if not ch_names:
-                    self.criticalNoTifFound(images_path)
-                    self.close()
-                    return
-                elif len(ch_names) > 1:
-                    ch_name_selector.QtPrompt(self, ch_names)
-                else:
-                    ch_name_selector.channel_name = ch_names[0]
-                ch_name_selector.setUserChannelName()
-                if ch_name_selector.was_aborted:
-                    self.processStopped()
-                    return
-                else:
-                    user_ch_name = ch_name_selector.channel_name
 
-            aligned_npz_found = False
-            tif_found = False
-            dataPrep_fn = None
-            for filename in filenames:
-                if filename.find(f'{user_ch_name}_aligned.npz') != -1:
-                    img_path = os.path.join(images_path, filename)
-                    idx = filename.find('_aligned.npz')
-                    dataPrep_fn = filename[:idx]
-                    aligned_npz_found = True
-                elif filename.find(f'{user_ch_name}.tif') != -1:
-                    img_path = os.path.join(images_path, filename)
-                    tif_found = True
+        ref_images_path = images_paths[0]
+        filenames = myutils.listdir(ref_images_path)
+        ch_names, warn = (
+            ch_name_selector.get_available_channels(
+                filenames, ref_images_path
+        ))
+        if not ch_names:
+            self.criticalNoTifFound(ref_images_path)
+            self.close()
+            return
+        elif len(ch_names) > 1:
+            ch_name_selector.QtPrompt(self, ch_names)
+        else:
+            ch_name_selector.channel_name = ch_names[0]
+        ch_name_selector.setUserChannelName()
+        if ch_name_selector.was_aborted:
+            self.processStopped()
+            return
+        else:
+            user_ch_name = ch_name_selector.channel_name
 
-            if not aligned_npz_found and not tif_found:
-                print('')
-                print('-------------------------------------------------------')
-                self.log(f'The folder {images_path}\n does not contain the file '
-                      f'{user_ch_name}_aligned.npz\n or the file {user_ch_name}.tif. '
-                      'Skipping it.')
-                print('-------------------------------------------------------')
-                print('')
-            elif not aligned_npz_found and tif_found:
-                print('')
-                print('-------------------------------------------------------')
-                self.log(f'The folder {images_path}\n does not contain the file '
-                      f'{user_ch_name}_aligned.npz. Segmenting .tif data.')
-                print('-------------------------------------------------------')
-                print('')
-                user_ch_file_paths.append(img_path)
-            elif aligned_npz_found:
-                user_ch_file_paths.append(img_path)
-
+        user_ch_file_paths = load.get_user_ch_paths(
+            images_paths, user_ch_name
+        )
+        
         self.numPos = len(user_ch_file_paths)
 
         selectROI = False

--- a/cellacdc/utils/base.py
+++ b/cellacdc/utils/base.py
@@ -368,50 +368,6 @@ class NewThreadMultipleExpBaseUtil(QDialog):
         
         self.worker.abort = cancel
         self.worker.waitCond.wakeAll()
-        
-        # # Get end name of every existing segmentation file
-        # existingSegmEndNames = set()
-        # for p, pos in enumerate(pos_foldernames):
-        #     pos_path = os.path.join(exp_path, pos)
-        #     images_path = os.path.join(pos_path, 'Images')
-        #     basename, chNames = myutils.getBasenameAndChNames(images_path)
-        #     # Use first found channel, it doesn't matter for metrics
-        #     for chName in chNames:
-        #         filePath = myutils.getChannelFilePath(images_path, chName)
-        #         if filePath:
-        #             break
-        #     else:
-        #         raise FileNotFoundError(
-        #             f'None of the channels "{chNames}" were found in the path '
-        #             f'"{images_path}".'
-        #         )
-        #     _posData = load.loadData(filePath, chName)
-        #     _posData.getBasenameAndChNames()
-        #     segm_files = load.get_segm_files(_posData.images_path)
-        #     _existingEndnames = load.get_endnames(
-        #         _posData.basename, segm_files
-        #     )
-        #     existingSegmEndNames.update(_existingEndnames)
-
-        # self.existingSegmEndNames = list(existingSegmEndNames)
-
-        # if len(existingSegmEndNames) == 1:
-        #     self.endFilenameSegm = list(existingSegmEndNames)[0]
-        #     self.worker.waitCond.wakeAll()
-        #     return
-
-        # if hasattr(self, 'infoText'):
-        #     infoText = self.infoText
-        # else:
-        #     infoText = None
-
-        # win = apps.SelectSegmFileDialog(
-        #     existingSegmEndNames, exp_path, parent=self, infoText=infoText
-        # )
-        # win.exec_()
-        # self.endFilenameSegm = win.selectedItemText
-        # self.worker.abort = win.cancel
-        # self.worker.waitCond.wakeAll()
 
     def skipEvent(self, dummy):
         self.worker.waitCond.wakeAll()

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -448,6 +448,12 @@ class reloadPushButton(PushButton):
         super().__init__(*args, **kwargs)
         self.setIcon(QIcon(':reload.svg'))
 
+class SegmentPushButton(PushButton):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setIcon(QIcon(':segment.svg'))
+
+
 class savePushButton(PushButton):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2864,7 +2864,8 @@ class myMessageBox(_base_widgets.QBaseDialog):
             commands=None, path_to_browse=None, browse_button_text=None,
             url_to_open=None, open_url_button_text='Open url', 
             image_paths=None, wrapDetails=True,
-            add_do_not_show_again_checkbox=False
+            add_do_not_show_again_checkbox=False,
+            details_expanded=True
         ):
         if parent is not None:
             self.setParent(parent)
@@ -2921,7 +2922,9 @@ class myMessageBox(_base_widgets.QBaseDialog):
                 buttons.append(button)
         
         if detailsText is not None:
-            self.setDetailedText(detailsText, visible=True, wrap=wrapDetails)
+            self.setDetailedText(
+                detailsText, visible=details_expanded, wrap=wrapDetails
+            )
         
         if add_do_not_show_again_checkbox:
             self.addDoNotShowAgainCheckbox()

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6743,3 +6743,56 @@ class CountObjectsInSegm(BaseWorkerUtil):
                 self.signals.progressBar.emit(1)
 
         self.signals.finished.emit(self)
+
+class CreateSymLinkToPosWinWorker(QObject):
+    def __init__(
+            self, 
+            exp_pos_mapper, 
+            dst_folderpath, 
+            exp_segm_files_to_copy_mapper
+        ):
+        QObject.__init__(self)
+        self.signals = signals()
+        self.logger = workerLogger(self.signals.progress)
+        
+        self._exp_pos_mapper = exp_pos_mapper
+        self._dst_folderpath = dst_folderpath
+        self._exp_segm_files_to_copy_mapper = exp_segm_files_to_copy_mapper
+    
+    def log_current_pos(self, src_pos_path, dst_pos_path):
+        sep = '-'*100
+        text = (
+            f'{sep}\nLinking following positions:\n\n'
+            f'{src_pos_path}\n'
+            f'--> {dst_pos_path}\n'
+        )
+        self.logger.log(text)
+    
+    @worker_exception_handler
+    def run(self):
+        for exp_path, pos_foldernames in self._exp_pos_mapper.items():
+            exp_foldername = os.path.basename(exp_path)
+            dst_exp_path = os.path.join(self._dst_folderpath, exp_foldername)
+            if os.path.exists(dst_exp_path):
+                raise FileExistsError(
+                    'The destination folder path already exists. '
+                    'Please, select a destination folder where '
+                    'the experiment folders do not exist. '
+                    f'Existing folder: "{dst_exp_path}"'
+                )
+            
+            segm_endanmes_to_copy = self._exp_segm_files_to_copy_mapper.get(
+                exp_path, []
+            )
+            for pos in pos_foldernames:
+                src_pos_path = os.path.join(exp_path, pos)
+                dst_pos_path = os.path.join(dst_exp_path, pos)
+                self.log_current_pos(src_pos_path, dst_pos_path)
+                load.create_symlinked_pos_folder(
+                    src_pos_path, 
+                    dst_pos_path, 
+                    segm_endanmes_to_copy
+                )
+                self.signals.progressBar.emit(1)
+                
+        self.signals.finished.emit(self)


### PR DESCRIPTION
This PR implements the use of "symbolic links" files instead of the classic TIFF files for image data. 

A symbolic link is a special type of file that acts as a pointer or alias, referring to another file by its path rather than its content.

In this case, the symbolic link is a `_symlink.ini` file that contains the information on how to read the source image file. 

This file can be created in the data structure module or by opening an image file in the module 3 GUI. 

See issue #1072 