### PR TITLE
Fix create data structure from ome.tif

### DIFF
--- a/cellacdc/acdc_regex.py
+++ b/cellacdc/acdc_regex.py
@@ -23,13 +23,29 @@ def get_function_names(text, include_class_methods=True):
         pattern = r'\ndef\s+([a-zA-Z_]\w*)\s*\('
     return re.findall(pattern, text)
 
-def is_alphanumeric_filename(text, allow_space=True):
+def is_alphanumeric_filename(
+        text, 
+        allow_space=True, 
+        allowed: str | list[str] | None=None
+    ):
     if allow_space:
         pattern = r'^[\w\-_. ]+$'
     else:
         pattern = r'^[\w\-_.]+$'
-    is_single_or_no_dot = len(re.findall(r'\.', text)) <= 1
-    return bool(re.match(pattern, text)) and is_single_or_no_dot
+    
+    if isinstance(allowed, str):
+        allowed = (allowed,)
+    
+    max_num_dots = 1
+    if allowed is not None:
+        max_num_dots += sum([txt.count('.') for txt in allowed])
+    
+    for allowed_text in allowed:
+        allowed_text = re.escape(allowed_text)
+        pattern = pattern.replace(r'+$', fr'+({allowed_text})?$')
+    
+    is_less_max_num_dots = len(re.findall(r'\.', text)) <= max_num_dots
+    return bool(re.match(pattern, text)) and is_less_max_num_dots
 
 def get_non_alphanumeric_characters(text):
     return re.findall(r'[^\w\-.]', text)

--- a/cellacdc/acdc_regex.py
+++ b/cellacdc/acdc_regex.py
@@ -33,6 +33,9 @@ def is_alphanumeric_filename(
     else:
         pattern = r'^[\w\-_.]+$'
     
+    if allowed is None:
+        allowed = []
+    
     if isinstance(allowed, str):
         allowed = (allowed,)
     

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -1927,8 +1927,11 @@ class createDataStructWin(QMainWindow):
         return files
 
     def checkFileNames(self, raw_filenames, raw_src_path):
+        allowed = (
+            '.ome.tif',
+        )
         for file in raw_filenames:
-            if not acdc_regex.is_alphanumeric_filename(file):
+            if not acdc_regex.is_alphanumeric_filename(file, allowed=allowed):
                 msg = widgets.myMessageBox(wrapText=False)
                 txt = html_utils.paragraph(
                     f"""

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -3683,7 +3683,10 @@ class OMEXML_Pixels:
             self.PhysicalSizeZ = node.get('PhysicalSizeZ', 1.0)
         
     def Channel(self, channel_index=0):
-        Channel = self.Pixels.findall(f'{self.ome_schema}Channel')[channel_index]
+        try:
+            Channel = self.Pixels.findall(f'{self.ome_schema}Channel')[channel_index]
+        except Exception as err:
+            Channel = 'not_found'
         return OMEXML_Channel(Channel)
 
 class OMEXML:
@@ -3731,7 +3734,7 @@ class OMEXML:
 
     def image(self):
         if self.root is None:
-            return 'undefined'
+            return OMEXML_image(None, 'not_found')
         
         Image = self.root.find(f'{self.ome_schema}Image')
         Pixels = Image.find(f'{self.ome_schema}Pixels')

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -3698,6 +3698,9 @@ class OMEXML:
     
     def parse_metadata(self):
         self.omexml_string = self.read_omexml_string()
+        if self.omexml_string is None:
+            return
+        
         self.root = ET.fromstring(self.omexml_string)
         self.ome_schema = re.findall(r'({.+})OME', self.root.tag)[0]
     

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -3659,8 +3659,12 @@ class OMEXML_intrument:
 
 class OMEXML_Channel:
     def __init__(self, Channel) -> None:
-        self.Name = Channel.attrib.get('Name', '')
-        self.node = Channel.attrib
+        if not Channel or Channel is None:
+            self.Name = 'not_found'
+            self.node = None
+        else:
+            self.Name = Channel.attrib.get('Name', '')
+            self.node = Channel.attrib
 
 class OMEXML_Pixels:
     def __init__(self, Pixels, node, ome_schema) -> None:
@@ -3686,7 +3690,7 @@ class OMEXML_Pixels:
         try:
             Channel = self.Pixels.findall(f'{self.ome_schema}Channel')[channel_index]
         except Exception as err:
-            Channel = 'not_found'
+            Channel = None
         return OMEXML_Channel(Channel)
 
 class OMEXML:

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -3697,6 +3697,8 @@ class OMEXML:
             return tif.ome_metadata
     
     def parse_metadata(self):
+        self.root = None
+        self.ome_schema = None
         self.omexml_string = self.read_omexml_string()
         if self.omexml_string is None:
             return
@@ -3706,6 +3708,9 @@ class OMEXML:
     
     def instrument(self):
         instrument = OMEXML_intrument()
+        if self.root is None:
+            return instrument
+        
         instrument_xml = self.root.find(f'{self.ome_schema}Instrument')
         if instrument_xml is None:
             return instrument
@@ -3719,9 +3724,15 @@ class OMEXML:
         return instrument
 
     def get_image_count(self):
+        if self.root is None:
+            return 1
+        
         return len(self.root.findall(f'{self.ome_schema}Image'))
 
     def image(self):
+        if self.root is None:
+            return 'undefined'
+        
         Image = self.root.find(f'{self.ome_schema}Image')
         Pixels = Image.find(f'{self.ome_schema}Pixels')
         image = OMEXML_image(Pixels, self.ome_schema)


### PR DESCRIPTION
This PR implements a fix for creating the data structure from `.ome.tif` files. 

More specifically:

- The `'.ome.tif'` must be allowed in the filename at line https://github.com/SchmollerLab/Cell_ACDC/blob/f1843a978405f4221a0aff418d00f85a6a3ac7b3/cellacdc/dataStruct.py#L1931 --> modified function with kwarg `allowed` --> `allowed = ( '.ome.tif',)
- Ignore if `self.omexml_string` at line https://github.com/SchmollerLab/Cell_ACDC/blob/f1843a978405f4221a0aff418d00f85a6a3ac7b3/cellacdc/load.py#L3700