### PR TITLE
Handle too many new objects when segmenting in GUI

### DIFF
--- a/cellacdc/_warnings.py
+++ b/cellacdc/_warnings.py
@@ -47,10 +47,9 @@ def warnTooManyNewItems(mainWin, numItems, qparent):
         What do you want to do?
     """)
 
-    _, switchToLowResButton, deactivateAnnotButton = msg.warning(
+    switchToLowResButton, deactivateAnnotButton = msg.warning(
         qparent, 'Too many objects', txt,
         buttonsTexts=(
-            'Cancel', 
             widgets.reloadPushButton(' Switch to low resolution '), 
             widgets.noPushButton(' Deactivate text annotations ')              
         )

--- a/cellacdc/_warnings.py
+++ b/cellacdc/_warnings.py
@@ -43,7 +43,7 @@ def warnTooManyNewItems(mainWin, numItems, qparent):
         Creating <b>high resolution</b> text annotations 
         for these many objects could take a <b>long time</b>.<br><br>
         We recommend <b>deactivating text annotations</b> or <b>switching to low resolution</b> annotations.<br><br>
-        You can still try to switch to activate them or switch to high resolution later.<br><br>
+        You can still try to activate them or switch to high resolution later.<br><br>
         What do you want to do?
     """)
 

--- a/cellacdc/_warnings.py
+++ b/cellacdc/_warnings.py
@@ -32,6 +32,34 @@ def warnTooManyItems(mainWin, numItems, qparent):
     )
     return msg.cancel, msg.clickedButton==switchToLowResButton
 
+def warnTooManyNewItems(mainWin, numItems, qparent):
+    from . import widgets
+    mainWin.logger.info(
+        '[WARNING]: asking user what to do with too many objects...'
+    )
+    msg = widgets.myMessageBox(wrapText=False)
+    txt = html_utils.paragraph(f"""
+        WARNING: The resulting segmentation mask has <b>{numItems} objects</b>.<br><br>
+        Creating <b>high resolution</b> text annotations 
+        for these many objects could take a <b>long time</b>.<br><br>
+        We recommend <b>deactivating text annotations</b> or <b>switching to low resolution</b> annotations.<br><br>
+        You can still try to switch to activate them or switch to high resolution later.<br><br>
+        What do you want to do?
+    """)
+
+    _, switchToLowResButton, deactivateAnnotButton = msg.warning(
+        qparent, 'Too many objects', txt,
+        buttonsTexts=(
+            'Cancel', 
+            widgets.reloadPushButton(' Switch to low resolution '), 
+            widgets.noPushButton(' Deactivate text annotations ')              
+        )
+    )
+    switchToLowRes = msg.clickedButton==switchToLowResButton
+    deactivateAnnot = msg.clickedButton==deactivateAnnotButton
+    
+    return msg.cancel, switchToLowRes, deactivateAnnot
+
 def warnRestartCellACDCcolorModeToggled(
         scheme, app_name='Cell-ACDC', parent=None
     ):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -30760,14 +30760,19 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     def checkHandleTooManyNewItems(self):
         posData = self.data[self.pos_i]
         num_objects = len(posData.rp)
-        if num_objects < 1500:
+        if num_objects <= 1500:
             return True
 
         out = _warnings.warnTooManyNewItems(self, num_objects, self)
-        cancel, switchToLowRes, deactivateAnnot = out
-        if cancel:
-            return False
+        closed, switchToLowRes, deactivateAnnot = out
+        if closed:
+            # Segmentation is already computed at this point; just proceed
+            return True
 
+        if not switchToLowRes and not deactivateAnnot:
+            # User chose to proceed without changing anything
+            return True
+    
         if switchToLowRes:
             self.highLowResAction.setChecked(False)
             self.changeTextResolution()

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -17564,11 +17564,13 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.update_rp(wl_update=False)
         self.tracking(enforce=True, against_next=posData.frame_i==0)
         
-        if self.isSnapshot:
-            self.fixCcaDfAfterEdit('Repeat segmentation')
-            self.updateAllImages()
-        else:
-            self.warnEditingWithCca_df('Repeat segmentation')
+        proceed = self.checkHandleTooManyNewItems()
+        if proceed:
+            if self.isSnapshot:
+                self.fixCcaDfAfterEdit('Repeat segmentation')
+                self.updateAllImages()
+            else:
+                self.warnEditingWithCca_df('Repeat segmentation')
 
         txt = f'Done. Segmentation computed in {exec_time:.3f} s'
         self.logger.info('-----------------')
@@ -30755,6 +30757,44 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
 
         self.setDrawAnnotComboboxTextRight(saveSettings=saveSettings)
 
+    def checkHandleTooManyNewItems(self):
+        posData = self.data[self.pos_i]
+        num_objects = len(posData.rp)
+        if num_objects < 1500:
+            return True
+
+        out = _warnings.warnTooManyNewItems(self, num_objects, self)
+        cancel, switchToLowRes, deactivateAnnot = out
+        if cancel:
+            return False
+
+        if switchToLowRes:
+            self.highLowResAction.setChecked(False)
+            self.changeTextResolution()
+            return True
+        
+        if deactivateAnnot:
+            self.annotCcaInfoCheckbox.blockSignals(True)
+            self.annotIDsCheckbox.blockSignals(True)
+            self.annotCcaInfoCheckbox.setChecked(False)
+            self.annotIDsCheckbox.setChecked(False)
+            self.annotCcaInfoCheckbox.blockSignals(False)
+            self.annotIDsCheckbox.blockSignals(False)
+
+            self.annotCcaInfoCheckboxRight.blockSignals(True)
+            self.annotIDsCheckboxRight.blockSignals(True)
+            self.annotCcaInfoCheckboxRight.setChecked(False)
+            self.annotIDsCheckboxRight.setChecked(False)
+            self.annotCcaInfoCheckboxRight.blockSignals(False)
+            self.annotIDsCheckboxRight.blockSignals(False)
+
+            self.textAnnot[0].setCcaAnnot(False)
+            self.textAnnot[0].setLabelAnnot(False)
+            self.textAnnot[1].setCcaAnnot(False)
+            self.textAnnot[1].setLabelAnnot(False)
+            return True
+
+    
     def setAnnotOptionsCcaMode(self):
         self.prevAnnotOptions = self.storeCurrentAnnotOptions_ax1(
             return_value=True


### PR DESCRIPTION
This PR implements the handling of having too many objects as the output of segmenting in the module 3 GUI. 

If more than 1.5k objects are detected, the user will be asked to either deactivate text annotations or switch to low resolution. 

Implements and closes #1114 