### PR TITLE
Correctly check numpy requirements of installed Numba

### DIFF
--- a/cellacdc/_run.py
+++ b/cellacdc/_run.py
@@ -622,24 +622,22 @@ def run_cli(ini_filepath):
     
     
 def _setup_numpy(caller_name='Cell-ACDC'):
-    import urllib.request
+    from importlib.metadata import requires
     import json
     import re
     
     from . import try_input_install_package
     
     numpy_versions = []
-    url = "https://pypi.org/pypi/numba/json"
+    
+
     try:
-        with urllib.request.urlopen(url) as response:
-            data = json.load(response)
-            requires_dist = data["info"].get("requires_dist", [])
-            numpy_versions = [
-                req for req in requires_dist if "numpy" in req.lower()
-            ]
-    except urllib.error.URLError as e:
-        print(f"Could not update np: {e}")
-        return
+        reqs = requires("numba") or []
+        numpy_versions = [
+            req for req in reqs if req.lower().startswith("numpy")
+        ]
+    except Exception:
+        reqs = []    
     
     if not numpy_versions:
         print(


### PR DESCRIPTION
With this PR, Cell-ACDC will check the Numpy requirements of the installed Numba, and not the latest Numba on PyPi.