### PR TITLE
Update button texts for position folder handling in data structure module

### DIFF
--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -2247,8 +2247,8 @@ class createDataStructWin(QMainWindow):
            buttonsTexts=(
                'Cancel', 
                'Overwrite', 
-               'Add files', 
-               widgets.newFilePushButton('Create new'),
+               'Add image files to existing Positions', 
+               widgets.newFilePushButton('Create new Position folders'),
             ),
            path_to_browse=exp_dst_path
         )


### PR DESCRIPTION
This PR changes the text of the buttons in the message box about existing position folders (data structure module) to a more verbose version to avoid confusion. 