### PR TITLE
Remove miniconda from installation instructions

### DIFF
--- a/cellacdc/docs/source/contributing.rst
+++ b/cellacdc/docs/source/contributing.rst
@@ -57,7 +57,7 @@ Development process
          # Install Cell-ACDC in developer mode
          pip install -e .
   
-     * ``conda`` (Miniconda, Miniforge etc.)
+     * ``conda`` (Miniforge)
 
        ::
 

--- a/cellacdc/docs/source/installation.rst
+++ b/cellacdc/docs/source/installation.rst
@@ -225,7 +225,7 @@ following command::
 Install latest version
 ----------------------
 
-1. Install `Miniconda <https://www.anaconda.com/download/success>`_ or `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_ 
+1. Install `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_ 
     Conda is the standard **package manager** for Python in the scientific 
     community.
 
@@ -359,7 +359,7 @@ Install from source (developer version)
 
 If you want to try out experimental features (and, if you have time, maybe report a bug or two :D), you can install the developer version from source as follows:
 
-1. Install `Miniconda <https://www.anaconda.com/download/success>`_ or `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_ 
+1. Install `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#install>`_ 
     Conda is the standard **package manager** for Python in the scientific 
     community.
 


### PR DESCRIPTION
This PR removes miniconda from installation instructions because Anaconda is blocked by several institutions