### PR TITLE
Fixes for exporting multichannel image and multiple threads management in combine channels

### DIFF
--- a/cellacdc/_warnings.py
+++ b/cellacdc/_warnings.py
@@ -382,3 +382,31 @@ def warnMissingCca(missing_cca_items, qparent=None):
     )
     doNotShowAgain = msg.doNotShowAgainCheckbox.isChecked()
     return msg.clickedButton == ignoreButton, doNotShowAgain
+
+def warnAskTransparencyModeNeededForExport(
+        mainWin, output='image', qparent=None
+    ):
+    if qparent is None:
+        qparent = mainWin
+        
+    from . import widgets
+    mainWin.logger.info(
+        '[WARNING]: prompting user to activate transparency mode for exporting '
+        'multichannel (overlay) image...'
+    )
+    msg = widgets.myMessageBox(wrapText=False)
+    txt = html_utils.paragraph(f"""
+        In order to export a multichannel (overlay) view to {output}, 
+        you need to activate 
+        <code>True transparency (RGBA composite)</code> mode.<br><br>
+        Without this mode, the intensity levels in the exported image would not 
+        correspond to the displayed image.<br><br>
+        Do you want to activate the transparency mode now?
+    """)
+
+    _, yesButton = msg.warning(
+        qparent, 'Transparency mode required', txt,
+        buttonsTexts=('Cancel', 'Yes, activate transparency mode')
+    )
+    
+    return msg.cancel, msg.clickedButton==yesButton

--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -27,6 +27,7 @@ from itertools import product
 import pathlib
 from natsort import natsorted
 import sympy as sp
+from copy import deepcopy
 
 from math import sqrt
 from scipy.stats import norm
@@ -2268,7 +2269,7 @@ def preprocess_image_from_recipe_multithread(
     return preprocessed_image
 
 def combine_channels_multithread(
-        steps: Dict[str, Dict[str, Any]],
+        inputs_info: Dict[str, Dict[str, Any]],
         formula: str,
         images_paths: List[str],
         keep_input_data_type: bool,
@@ -2286,6 +2287,8 @@ def combine_channels_multithread(
                 total=len(images_paths), ncols=100, desc='Combining channels'
             )
         
+        inputs_info_copies = [deepcopy(inputs_info) for _ in images_paths]
+        
         func = partial(
             combine_channels_executor_map,
             keep_input_data_type=keep_input_data_type,
@@ -2293,9 +2296,8 @@ def combine_channels_multithread(
             logger_func=logger_func,
             output_as_segm=output_as_segm,
             formula=formula,
-            steps=steps,
         )
-        iterable = zip(images_paths, save_filepaths)
+        iterable = zip(images_paths, save_filepaths, inputs_info_copies)        
         result = executor.map(func, iterable)
         for res in result:
             if signals:
@@ -2314,8 +2316,9 @@ def combine_channels_multithread_return_imgs(
         output_as_segm: bool = False,
         formula: str = None,
     ):
-
-
+    # NOTE: `steps` is the same as `inputs_info` in 
+    # `combine_channels_multithread`. It's called steps only because it would 
+    # be harder to rename. `inputs_info` would be a better name
     total = len(keys)
     
     output_imgs = [None] * total
@@ -2365,9 +2368,10 @@ def combine_channels_multithread_return_imgs(
     return output_imgs, keys_out
 
 def combine_channels_executor_map(args, **kwargs):
-    images_path, save_filepath = args
+    images_path, save_filepath, inputs_info = args
     kwargs['save_filepath'] = save_filepath
     kwargs['images_path'] = images_path
+    kwargs['inputs_info'] = inputs_info
     return combine_channels_func(**kwargs)
 
 def combine_channels_executor_map_return_img(args, **kwargs):
@@ -2529,7 +2533,7 @@ def _update_target_shape_target_dims(target_dims, target_shape, img_data):
         
 
 def combine_channels_func(
-        steps: Dict[str, Dict[str, Any]],
+        inputs_info: Dict[str, Dict[str, Any]],
         keep_input_data_type: bool,
         save_filepath: str=None,
         return_img: bool=False,
@@ -2551,11 +2555,17 @@ def combine_channels_func(
     fluo_ch_data_list = dict()
     segm_ch_data_list = dict()
     
+<<<<<<< Updated upstream
     channel_names = [step['channel'] for step in steps.values()]
     channel_keys = steps.keys()
     segm_channels, fluo_channel_names, current_segm = (
         myutils.separate_fluo_segment_channels(channel_names)
     )
+=======
+    channel_names = [step['channel'] for step in inputs_info.values()]
+    channel_keys = inputs_info.keys()
+    segm_channels, fluo_channel_names, current_segm = myutils.separate_fluo_segment_channels(channel_names)
+>>>>>>> Stashed changes
     original_dtype = None
     
     target_dims = 0
@@ -2575,10 +2585,15 @@ def combine_channels_func(
                  target_dims, target_shape, ch_image_data
             )
             fluo_ch_data_list[channel] = ch_image_data
+<<<<<<< Updated upstream
         
         for channel in segm_channels:
+=======
+            
+        for segm_channel in segm_channels:
+>>>>>>> Stashed changes
             ch_filepath = load.get_filepath_from_endname(
-                images_path, channel
+                images_path, segm_channel
             )
             ch_image_data = load.load_image_file(ch_filepath)
             if original_dtype is None:
@@ -2588,7 +2603,7 @@ def combine_channels_func(
             target_dims, target_shape = _update_target_shape_target_dims(
                  target_dims, target_shape, ch_image_data
             )
-            segm_ch_data_list[channel] = ch_image_data
+            segm_ch_data_list[segm_channel] = ch_image_data
     else:
         posData = data[key[0]]
         n_dim = 4
@@ -2683,26 +2698,26 @@ def combine_channels_func(
             segm_ch_data_list[ch] = ch_image_data
         else:
             raise ValueError(f'Channel "{ch}" not found.')
-        if steps[i]['channel'] != ch:
+        if inputs_info[i]['channel'] != ch:
             raise ValueError(f'Channel "{ch}" not found.')        
-        steps[i]['channel_data'] = ch_image_data
+        inputs_info[i]['channel_data'] = ch_image_data
     
-    for i, step_info in steps.items():
+    for i, step_info in inputs_info.items():
         binarize = step_info['binarize']
-        steps[i]['channel_data'] = _combine_channels_multiplier_apply(
+        inputs_info[i]['channel_data'] = _combine_channels_multiplier_apply(
             binarize, step_info['channel_data']
         )
         norm_min, norm_max = step_info['min_val'], step_info['max_val']
         # use rescale_intensity to normalize
         if norm_min == 0 and norm_max == 1:
             continue # cases where either the fields where disabled/reset or default, where we already normalized
-        steps[i]['channel_data'] = skimage.exposure.rescale_intensity(
-            steps[i]['channel_data'], 
+        inputs_info[i]['channel_data'] = skimage.exposure.rescale_intensity(
+            inputs_info[i]['channel_data'], 
             out_range=(norm_min, norm_max)
         )
     
     if formula != '':
-        input_img_data = {step['name']: step['channel_data'] for step in steps.values()}
+        input_img_data = {step['name']: step['channel_data'] for step in inputs_info.values()}
         
         symbols = {name: sp.Symbol(name) for name in input_img_data}
         expr = sp.sympify(formula, locals=symbols)
@@ -2717,8 +2732,8 @@ def combine_channels_func(
         args = [input_img_data[v] for v in used_vars]
         output_img = func(*args)
     else:
-        key0 = list(steps.keys())[0]
-        output_img = steps[key0]['channel_data']
+        key0 = list(inputs_info.keys())[0]
+        output_img = inputs_info[key0]['channel_data']
 
     if not output_as_segm:
         output_img = skimage.exposure.rescale_intensity(

--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -2555,17 +2555,11 @@ def combine_channels_func(
     fluo_ch_data_list = dict()
     segm_ch_data_list = dict()
     
-<<<<<<< Updated upstream
-    channel_names = [step['channel'] for step in steps.values()]
-    channel_keys = steps.keys()
+    channel_names = [step['channel'] for step in inputs_info.values()]
+    channel_keys = inputs_info.keys()
     segm_channels, fluo_channel_names, current_segm = (
         myutils.separate_fluo_segment_channels(channel_names)
     )
-=======
-    channel_names = [step['channel'] for step in inputs_info.values()]
-    channel_keys = inputs_info.keys()
-    segm_channels, fluo_channel_names, current_segm = myutils.separate_fluo_segment_channels(channel_names)
->>>>>>> Stashed changes
     original_dtype = None
     
     target_dims = 0
@@ -2585,13 +2579,8 @@ def combine_channels_func(
                  target_dims, target_shape, ch_image_data
             )
             fluo_ch_data_list[channel] = ch_image_data
-<<<<<<< Updated upstream
-        
-        for channel in segm_channels:
-=======
             
         for segm_channel in segm_channels:
->>>>>>> Stashed changes
             ch_filepath = load.get_filepath_from_endname(
                 images_path, segm_channel
             )

--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -2553,7 +2553,9 @@ def combine_channels_func(
     
     channel_names = [step['channel'] for step in steps.values()]
     channel_keys = steps.keys()
-    segm_channels, fluo_channel_names, current_segm = myutils.separate_fluo_segment_channels(channel_names)
+    segm_channels, fluo_channel_names, current_segm = (
+        myutils.separate_fluo_segment_channels(channel_names)
+    )
     original_dtype = None
     
     target_dims = 0
@@ -2573,6 +2575,7 @@ def combine_channels_func(
                  target_dims, target_shape, ch_image_data
             )
             fluo_ch_data_list[channel] = ch_image_data
+        
         for channel in segm_channels:
             ch_filepath = load.get_filepath_from_endname(
                 images_path, channel
@@ -2605,7 +2608,8 @@ def combine_channels_func(
             channel_full_name = pathlib.Path(channel_path).stem
             # remove the file extension
             
-            channel_img_data = _get_img_from_data_key(fluo_data_dict[channel_full_name], key, n_dim)
+            channel_img_data = _get_img_from_data_key(
+                fluo_data_dict[channel_full_name], key, n_dim)
             if original_dtype is None:
                 original_dtype = channel_img_data.dtype
             channel_img_data_float = myutils.img_to_float(channel_img_data)
@@ -2666,14 +2670,16 @@ def combine_channels_func(
     for i, ch in zip(channel_keys, channel_names):
         if ch in fluo_ch_data_list:
             ch_image_data = fluo_ch_data_list[ch]
-            _verify_shape_ndim(ch_image_data, target_dims, target_shape, is_segm=False)
+            _verify_shape_ndim(
+                ch_image_data, target_dims, target_shape, is_segm=False)
 
         elif ch in segm_ch_data_list:
             ch_image_data = segm_ch_data_list[ch]
             ch_image_data, text = _add_missing_dims(ch_image_data, target_shape)
             if text:
                 _log_printl_fallback(text, logger_func)
-            _verify_shape_ndim(ch_image_data, target_dims, target_shape, is_segm=False) # false since we already expanded
+            _verify_shape_ndim(
+                ch_image_data, target_dims, target_shape, is_segm=False) # false since we already expanded
             segm_ch_data_list[ch] = ch_image_data
         else:
             raise ValueError(f'Channel "{ch}" not found.')
@@ -2767,10 +2773,15 @@ def combine_channels_func(
     if return_img:
         return output_img, key, txt
     
-    txt = f'Saving combined {"segmentation" if output_as_segm else "image"} to {save_filepath}'
+    txt = (
+        f'Saving combined {"segmentation" if output_as_segm else "image"} to '
+        f'{save_filepath}'
+    )
     _log_printl_fallback(txt, logger_func)
     
 
+    printl(save_filepath)
+    
     io.save_image_data( # handles saving img and segm
         save_filepath, output_img
     )

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -3140,7 +3140,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 # self.rescaleIntensitiesLut(setImage=setImage)
                 break
     
-    def customLevelsLutChanged(self, levels, imageItem=None):
+    def customLevelsLutChanged(self, levels, imageItem: pg.ImageItem=None):
         imageItem.setLevels(levels)
     
     def getPreComputedMinMaxZstack(self, channel: str):
@@ -31092,7 +31092,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             if otherToolbutton.isChecked() and isSingleChannel:
                 op_val = 1.0
             elif otherToolbutton.isChecked():
-                op_val = channel_opacity_mapper[channel]
+                op_val = channel_opacity_mapper.get(channel, 0.01)
             else:
                 op_val = 0.0
             

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -3237,13 +3237,13 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             if triggeredByUser:
                 current_min, current_max = imageItem.getLevels() 
                 dtype_max = np.iinfo(image_data.dtype).max
-                max_value = image_data.max()
-                min_value = image_data.min()
+                # max_value = image_data.max()
+                # min_value = image_data.min()
                 win = apps.SetCustomLevelsLut(
-                    init_min_value=current_min,
-                    init_max_value=current_max,
-                    maximum_max_value=max_value,
-                    minimum_min_value=min_value,
+                    init_min_value=round(current_min),
+                    init_max_value=round(current_max),
+                    maximum_max_value=dtype_max,
+                    minimum_min_value=0,
                     parent=self
                 )
                 win.sigLevelsChanged.connect(
@@ -30929,7 +30929,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             how = self.df_settings.at[
                 f'how_rescale_intensities_{channelName}', 'value'
             ]
-            lutItem.setRescaleIntensitiesHow(how)
+            if not 'custom' in how:
+                lutItem.setRescaleIntensitiesHow(how)
         
         self.rescaleIntensChannelHowMapper[channelName] = (
             'Rescale each 2D image'
@@ -32050,7 +32051,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.ccaTableWin.updateTable(posData.cca_df, IDs=zoomIDs)
     
     @disableWindow
-    def exportToImage(self, preferences):        
+    def exportToImage(self, preferences):      
         filepath = preferences['filepath']
         self.logger.info(f'Saving image to "{filepath}"...')
         
@@ -32058,6 +32059,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             exporter = exporters.SVGExporter(self.ax1)
         else:
             exporter = exporters.ImageExporter(self.ax1, dpi=preferences['dpi'])
+        
         exporter.export(filepath)
         self.logger.info(f'Image saved.')
         

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -3142,6 +3142,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     
     def customLevelsLutChanged(self, levels, imageItem: pg.ImageItem=None):
         imageItem.setLevels(levels)
+        if self.overlayToolbar.isTransparent():
+            self.updateTransparentOverlayRgba()
     
     def getPreComputedMinMaxZstack(self, channel: str):
         if channel != self.user_ch_name:
@@ -25461,12 +25463,22 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 toolbutton = items[3]
                 if not toolbutton.isChecked():
                     continue
+                
+                rescale_lut_action = (
+                    imageItem.lutItem.rescaleActionGroup.checkedAction()
+                )
+                rescale_lut_how = rescale_lut_action.text()
+                if rescale_lut_how == 'Choose custom levels...':
+                    out_range = imageItem.getLevels()
+                    ol_img = skimage.exposure.rescale_intensity(
+                        ol_img, out_range=out_range
+                    ) 
+                    
                 alpha_val = alphaSB.value()/alphaSB.maximum()
                 ol_img = skimage.exposure.rescale_intensity(
                     ol_img, out_range=(0.0, 1.0)
-                )
-                out_range_min, out_range_max = lutItem.getLevels()                
-                rgba_imgs_info[chName] = (ol_img, alpha_val, lutItem)
+                )               
+                rgba_imgs_info[chName] = (ol_img, alpha_val, lutItem, imageItem)
             else:
                 self.rescaleIntensitiesLut(setImage=False, imageItem=imageItem)
                 imageItem.setImage(ol_img)
@@ -25478,7 +25490,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         images = []
         luts = []
         for channel, info in rgba_imgs_info.items():
-            ol_img, alpha_val, lutItem = info
+            ol_img, alpha_val, lutItem, imageItem = info
             alpha_values.append(alpha_val)
             images.append(ol_img)
             luts.append(lutItem.gradient.getLookupTable(256, alpha=255)/255)
@@ -25487,6 +25499,15 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         if self.baseLayerToolbutton.isChecked():
             image1 = self._getImageupdateAllImages()
+            rescale_lut_action = (
+                self.imgGrad.rescaleActionGroup.checkedAction()
+            )
+            rescale_lut_how = rescale_lut_action.text()
+            if rescale_lut_how == 'Choose custom levels...':
+                out_range = self.img1.getLevels()
+                ol_img = skimage.exposure.rescale_intensity(
+                    ol_img, out_range=out_range
+                ) 
             image1 = skimage.exposure.rescale_intensity(
                 image1, out_range=(0.0, 1.0)
             )        

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -25468,15 +25468,13 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     imageItem.lutItem.rescaleActionGroup.checkedAction()
                 )
                 rescale_lut_how = rescale_lut_action.text()
+                in_range = 'image'
                 if rescale_lut_how == 'Choose custom levels...':
-                    out_range = imageItem.getLevels()
-                    ol_img = skimage.exposure.rescale_intensity(
-                        ol_img, out_range=out_range
-                    ) 
+                    in_range = tuple(imageItem.getLevels())
                     
                 alpha_val = alphaSB.value()/alphaSB.maximum()
                 ol_img = skimage.exposure.rescale_intensity(
-                    ol_img, out_range=(0.0, 1.0)
+                    ol_img, in_range=in_range, out_range=(0.0, 1.0)
                 )               
                 rgba_imgs_info[chName] = (ol_img, alpha_val, lutItem, imageItem)
             else:
@@ -25503,13 +25501,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 self.imgGrad.rescaleActionGroup.checkedAction()
             )
             rescale_lut_how = rescale_lut_action.text()
+            in_range = 'image'
             if rescale_lut_how == 'Choose custom levels...':
-                out_range = self.img1.getLevels()
-                ol_img = skimage.exposure.rescale_intensity(
-                    ol_img, out_range=out_range
-                ) 
+                in_range = tuple(self.img1.getLevels())
+                
             image1 = skimage.exposure.rescale_intensity(
-                image1, out_range=(0.0, 1.0)
+                image1, in_range=in_range, out_range=(0.0, 1.0)
             )        
             images.append(image1)
             baseLut = (
@@ -31954,8 +31951,39 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             return 
         
         return msg.clickedButton == timelapseButton
+
+    def exportToCheckAskOverlay(self, output='image'):
+        if not self.overlayButton.isChecked():
+            return True
+        
+        if self.overlayToolbar.isTransparent():
+            return True
+        
+        self.blinker = qutils.QControlBlink(
+            self.overlayToolbar.transparencyCheckbox, qparent=self
+        )
+        self.blinker.start()
+        
+        cancel, activateTransparencyMode = (
+            _warnings.warnAskTransparencyModeNeededForExport(
+                self, output=output
+            )
+        )
+        
+        if cancel:
+            return False
+        
+        if activateTransparencyMode:
+            self.overlayToolbar.setTransparent(True)
+        
+        return True
     
     def exportToVideoTriggered(self):
+        proceed = self.exportToCheckAskOverlay(output='video')
+        if not proceed:
+            self.logger.info('Export to video process cancelled')
+            return
+        
         posData = self.data[self.pos_i]
         
         doTimelapseVideo = posData.SizeT > 1
@@ -32090,6 +32118,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         prompts.exportToImageFinished(filepath, qparent=self)
     
     def exportToImageTriggered(self):
+        proceed = self.exportToCheckAskOverlay()
+        if not proceed:
+            self.logger.info('Export to video process cancelled')
+            return
+        
         posData = self.data[self.pos_i]
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
         filename = f'{timestamp}_acdc_exported_image'

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -7015,7 +7015,7 @@ class sliderWithSpinBox(QWidget):
             valueInt = int(value*self.slider.maximum())
         elif self._isFloat:
             valueInt = int(value)
-
+        
         self.spinBox.valueChanged.disconnect()
         self.spinBox.setValue(value)
         self.spinBox.valueChanged.connect(self.spinboxValueChanged)

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6048,8 +6048,6 @@ class CombineChannelsWorkerUtil(BaseWorkerUtil):
             out_ext = '.tif'
             basename_ext = ''
         
-        printl(image_paths, pretty=True)
-        
         for images_path in image_paths:
             basename, channels = myutils.getBasenameAndChNames(images_path)
             
@@ -6059,9 +6057,6 @@ class CombineChannelsWorkerUtil(BaseWorkerUtil):
 
             images_path_to_process.append(images_path)
             save_filepaths.append(os.path.join(images_path, savename))
-            
-        printl(save_filepaths, pretty=True)
-        printl(images_path_to_process, pretty=True)
         
         core.combine_channels_multithread(
             inputs_info=steps,

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6047,6 +6047,9 @@ class CombineChannelsWorkerUtil(BaseWorkerUtil):
         else:
             out_ext = '.tif'
             basename_ext = ''
+        
+        printl(image_paths, pretty=True)
+        
         for images_path in image_paths:
             basename, channels = myutils.getBasenameAndChNames(images_path)
             
@@ -6056,6 +6059,9 @@ class CombineChannelsWorkerUtil(BaseWorkerUtil):
 
             images_path_to_process.append(images_path)
             save_filepaths.append(os.path.join(images_path, savename))
+            
+        printl(save_filepaths, pretty=True)
+        printl(images_path_to_process, pretty=True)
         
         core.combine_channels_multithread(
             steps=steps,

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -6064,7 +6064,7 @@ class CombineChannelsWorkerUtil(BaseWorkerUtil):
         printl(images_path_to_process, pretty=True)
         
         core.combine_channels_multithread(
-            steps=steps,
+            inputs_info=steps,
             images_paths=images_path_to_process,
             keep_input_data_type=keep_input_data_type,
             save_filepaths=save_filepaths,


### PR DESCRIPTION
When exporting a multichannel image from module 3 GUI, the SVG exporter is not respecting the custom levels. 

Best solution is to enforce true transparency RGBA to export multi-channel images.

However, custom levels do nothing when transparency RGBA mode is active.

To do:

- [ ] Custom levels with true transparecy mode