### PR TITLE
Unescape HTML commands before copy to clipboard

### DIFF
--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -2892,6 +2892,7 @@ def _install_pip_package(
         force_binary: bool = True,
         pref_binary: bool = True,
         ) -> None:
+    pkg_name = pkg_name.replace('"', '')
     command = [sys.executable, '-m', 'pip', 'install', pkg_name,]
     if force_binary:
         command.append('--only-binary=:all:')
@@ -3199,6 +3200,8 @@ def install_package_conda(conda_pkg_name, channel='conda-forge'):
         raise EnvironmentError(
             'Cell-ACDC is not running in a `conda` environment.'
         )
+    
+    conda_pkg_name = conda_pkg_name.replace('"', '')
     conda_prefix, pip_prefix = get_pip_conda_prefix()
     conda_prefix = re.sub(
         r'(-c\sconda-forge\s?|--channel=conda-forge\s?)', f'-c {channel} ', 
@@ -3477,7 +3480,9 @@ def check_install_package(
                     including_lower_version=include_lower_version,
                 )
                 if installer == 'pip':
-                    _install_pip_package(pkg_command, install_dependencies=install_dependencies)
+                    _install_pip_package(
+                        pkg_command, install_dependencies=install_dependencies
+                    )
                 else:
                     install_package_conda(pkg_command)
         except Exception as e:
@@ -3718,6 +3723,7 @@ def _get_pkg_command_pip_install(
     ):
     if exact_version:
         pkg_command = f'{pkg_command}=={exact_version}'
+        pkg_command = f'"{pkg_command}"'
         return pkg_command
     
     if including_higher_version:
@@ -3735,7 +3741,9 @@ def _get_pkg_command_pip_install(
     
     if max_version:
         pkg_command = f'{pkg_command}{sign_max}{max_version}'
-        
+    
+    pkg_command = f'"{pkg_command}"'
+    
     return pkg_command
 
 def _install_package_cli_msg(
@@ -3776,8 +3784,6 @@ def _install_package_cli_msg(
     )
     logger_func(txt)
     
-    
-        
     while True:
         answer = try_input_install_package(pkg_name, install_command)
         if not answer or answer.lower() == 'y':
@@ -3853,6 +3859,8 @@ def _install_tensorflow(max_version='', min_version=''):
         min_version=min_version
     )
     conda_prefix, pip_prefix = get_pip_conda_prefix()
+    
+    pkg_command = pkg_command.replace('"', '')
 
     if is_mac and cpu == 'arm':
         args = [f'{conda_prefix} "{pkg_command}"']

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -3718,6 +3718,7 @@ def _get_pkg_command_pip_install(
     ):
     if exact_version:
         pkg_command = f'{pkg_command}=={exact_version}'
+        pkg_command = f'"{pkg_command}"'
         return pkg_command
     
     if including_higher_version:
@@ -3736,6 +3737,7 @@ def _get_pkg_command_pip_install(
     if max_version:
         pkg_command = f'{pkg_command}{sign_max}{max_version}'
         
+    pkg_command = f'"{pkg_command}"'
     return pkg_command
 
 def _install_package_cli_msg(

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -3724,7 +3724,6 @@ def _get_pkg_command_pip_install(
     if exact_version:
         pkg_command = f'{pkg_command}=={exact_version}'
         pkg_command = f'"{pkg_command}"'
-        pkg_command = f'"{pkg_command}"'
         return pkg_command
     
     if including_higher_version:
@@ -3743,10 +3742,7 @@ def _get_pkg_command_pip_install(
     if max_version:
         pkg_command = f'{pkg_command}{sign_max}{max_version}'
         
-    pkg_command = f'"{pkg_command}"'
-    
-    pkg_command = f'"{pkg_command}"'
-    
+    pkg_command = f'"{pkg_command}"'    
     return pkg_command
 
 def _install_package_cli_msg(

--- a/cellacdc/segm.py
+++ b/cellacdc/segm.py
@@ -397,6 +397,11 @@ class segmWin(QMainWindow):
                 self.close()
                 return
 
+        if len(images_paths) == 0:
+            self.criticalEmptySelection()
+            self.close()
+            return
+            
         ref_images_path = images_paths[0]
         filenames = myutils.listdir(ref_images_path)
         ch_names, warn = (
@@ -934,6 +939,14 @@ class segmWin(QMainWindow):
         )
         msg = widgets.myMessageBox()
         msg.addShowInFileManagerButton(images_path)
+        msg.critical(self, err_title, err_msg)
+
+    def criticalEmptySelection(self):
+        err_title = 'Empty selection of folders'
+        err_msg = html_utils.paragraph(
+            'Please select at least one experiment folder to analyse.<br><br>'
+        )
+        msg = widgets.myMessageBox()
         msg.critical(self, err_title, err_msg)
     
     def criticalNoTifFound(self, images_path):

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -17,6 +17,8 @@ import random
 from functools import partial
 from math import ceil
 
+import html
+
 import skimage.draw
 import skimage.morphology
 
@@ -2610,8 +2612,6 @@ class myMessageBox(_base_widgets.QBaseDialog):
         self.currentRow += 1
     
     def copyToClipboard(self):
-        import html
-        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
         plain_text = html.unescape(self.sender()._command).replace("\xa0", " ")
@@ -7793,9 +7793,7 @@ class CopiableCommandWidget(QGroupBox):
     def setWordWrap(self, wordWrap):
         self.label.setWordWrap(wordWrap)
     
-    def copyToClipboard(self):
-        import html
-        
+    def copyToClipboard(self):        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
         plain_command = html.unescape(self._command).replace("\xa0", " ")
@@ -10404,8 +10402,6 @@ class installJavaDialog(myMessageBox):
         self.scrollArea.hide()
 
     def copyToClipboard(self):
-        import html
-        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
         plain_text = html.unescape(self.sender().textToCopy).replace("\xa0", " ")

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -2610,9 +2610,12 @@ class myMessageBox(_base_widgets.QBaseDialog):
         self.currentRow += 1
     
     def copyToClipboard(self):
+        import html
+        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
-        cb.setText(self.sender()._command, mode=cb.Clipboard)
+        plain_text = html.unescape(self.sender()._command).replace("\xa0", " ")
+        cb.setText(plain_text, mode=cb.Clipboard)
         print('Command copied!')
 
     def addButton(self, buttonText):
@@ -7791,9 +7794,12 @@ class CopiableCommandWidget(QGroupBox):
         self.label.setWordWrap(wordWrap)
     
     def copyToClipboard(self):
+        import html
+        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
-        cb.setText(self._command, mode=cb.Clipboard)
+        plain_command = html.unescape(self._command).replace("\xa0", " ")
+        cb.setText(plain_command, mode=cb.Clipboard)
         print('Command copied!')
     
     def setCommand(self, command, font_size=None):
@@ -10398,9 +10404,12 @@ class installJavaDialog(myMessageBox):
         self.scrollArea.hide()
 
     def copyToClipboard(self):
+        import html
+        
         cb = QApplication.clipboard()
         cb.clear(mode=cb.Clipboard)
-        cb.setText(self.sender().textToCopy, mode=cb.Clipboard)
+        plain_text = html.unescape(self.sender().textToCopy).replace("\xa0", " ")
+        cb.setText(plain_text, mode=cb.Clipboard)
         print('Command copied!')
 
     def showInstructions(self, checked):


### PR DESCRIPTION
This PR implements `html.unescape` to replace HTML characters with the plain text equivalent in every copy to clipboard method.