### PR TITLE
Shortcuts, closes #1142 

### DIFF
--- a/cellacdc/QtScoped.py
+++ b/cellacdc/QtScoped.py
@@ -61,3 +61,23 @@ def QStyleSC_ScrollBarSubLine():
         return QStyle.SubControl.SC_ScrollBarSubLine
     else:
         return QStyle.SC_ScrollBarSubLine
+    
+    
+if not PYQT6:
+    mouse_button_names_mapper = {
+        getattr(Qt, name): name
+        for name in dir(Qt)
+        if not name.startswith('_')
+        and isinstance(getattr(Qt, name), int)
+        and (name.lower().startswith('xbutton')
+            or name.lower().startswith('extrabutton')
+            or name.lower().startswith('leftbutton')
+            or name.lower().startswith('rightbutton')
+            or name.lower().startswith('middlebutton'))
+    }
+
+def mouse_button_name(button):
+    if PYQT6:
+        return button.name
+    else:
+        return mouse_button_names_mapper.get(button, str(button))

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -14973,7 +14973,10 @@ class ShortcutEditorDialog(QBaseDialog):
             text = shortcutLineEdit.text()
             if shortcutLineEdit.isShortcutMouseButton:
                 button_name = text.split('Mouse ')[-1]
-                button = Qt.MouseButton[button_name]
+                button = getattr(Qt.MouseButton, button_name, None)
+                if button is None:
+                    printl(f'Warning: could not find mouse button for {button_name}')
+                    continue
                 self.mouseBindings[name] = button
                 self.customShortcuts[name] = (text, button)
             elif shortcutLineEdit.isShortcutKeyPress:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -14901,6 +14901,7 @@ class ShortcutEditorDialog(QBaseDialog):
     def shortcutChanged(self, text):
         sender = self.sender()
         self.checkDuplicateShortcuts(text, sender=sender)
+        self.updateMouseBindings(text, sender=sender)
     
     def updateMouseBindings(self, text, sender=None):
         if sender is None:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -52,7 +52,8 @@ pg.setConfigOption('imageAxisOrder', 'row-major')
 from qtpy import QtCore
 from qtpy.QtGui import (
     QIcon, QFontMetrics, QKeySequence, QFont, QRegularExpressionValidator, 
-    QCursor, QKeyEvent, QPixmap, QFont, QPalette, QMouseEvent, QColor
+    QCursor, QKeyEvent, QPixmap, QFont, QPalette, QMouseEvent, QColor,
+    QTextDocument
 )
 from qtpy.QtCore import (
     Qt, QSize, QEvent, Signal, QEventLoop, QTimer, QRegularExpression
@@ -14633,10 +14634,18 @@ class ShortcutEditorDialog(QBaseDialog):
             zoomOutKeyValue: int=None,
             parent=None,
             mouseBindings: dict=None,
-            widgetsPercistantShortcuts: dict=None
+            hard_shortcuts: dict=None
         ):
         self.cancel = True
         super().__init__(parent)
+
+        
+        # convert hard_shortcuts keys using widgets.KeySequenceFromText and to_string
+        self.new_hard_shortcuts = {}
+        for shortcut, name in hard_shortcuts.items():
+            shortcut = widgets.KeySequenceFromText(shortcut)
+            shortcut_str = shortcut.toString()
+            self.new_hard_shortcuts[name] = shortcut_str
 
         self.setWindowTitle('Customize keyboard shortcuts')
 
@@ -14650,7 +14659,20 @@ class ShortcutEditorDialog(QBaseDialog):
         scrollAreaWidget = QWidget()
         entriesLayout = QGridLayout()
         
+        conflict_prefix = 'Conflict with '
+        all_names = list(widgetsWithShortcut.keys()) + list(self.new_hard_shortcuts.keys())
+        longest_name = max(all_names, key=len)
+        self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name}</font>'
+        longest_conflict_text = self.conflict_text_formatter(longest_name)
+
+        doc = QTextDocument()
+        warnConflictLabel = QLabel(longest_conflict_text)
+        doc.setDefaultFont(warnConflictLabel.font())
+        doc.setHtml(longest_conflict_text)
+        max_warn_width = int(doc.idealWidth() + 10)
+        
         row = 0
+        name = 'Delete object'
         button = widgets.PushButton(self, flat=True)
         button.setIcon(QIcon(":del_obj_click.svg"))
         self.delObjShortcutLineEdit = widgets.ShortcutLineEdit(
@@ -14668,6 +14690,10 @@ class ShortcutEditorDialog(QBaseDialog):
         entriesLayout.addWidget(
             self.delObjButtonCombobox, row, 3, alignment=Qt.AlignLeft
         )
+        warnConflictLabel = QLabel('')
+        self.delObjShortcutLineEdit.warnConflictLabel = warnConflictLabel
+        entriesLayout.addWidget(warnConflictLabel, row, 4)
+        warnConflictLabel.setMinimumWidth(max_warn_width)
         
         row += 1
         name = 'Zoom out'
@@ -14685,9 +14711,14 @@ class ShortcutEditorDialog(QBaseDialog):
         entriesLayout.addWidget(label, row, 1)
         entriesLayout.addWidget(self.zoomShortcutLineEdit, row, 2)
         self.shortcutLineEdits[name] = self.zoomShortcutLineEdit
+        warnConflictLabel = QLabel('')
+        self.zoomShortcutLineEdit.warnConflictLabel = warnConflictLabel
+        entriesLayout.addWidget(warnConflictLabel, row, 4)
+        warnConflictLabel.setMinimumWidth(max_warn_width)
         
         row += 1
         
+        # sort dicitonaries
         keep_at_beginning = ['Next', 'Previous']
 
         grouped_keys = {
@@ -14696,30 +14727,18 @@ class ShortcutEditorDialog(QBaseDialog):
             '(lineage tree)': [],
         }
 
+        widgetsWithShortcut = self._groupAndSortShortcuts(
+            widgetsWithShortcut, keep_at_beginning, grouped_keys
+        )
+
         grouped_keys = {
             'keep_at_beginning': [],
             'other': [],
-            '(lineage tree)': [],
         }
-
-        for key in widgetsWithShortcut.keys():
-            if key in keep_at_beginning:
-                grouped_keys['keep_at_beginning'].append(key)
-            elif '(lineage tree)' in key:
-                grouped_keys['(lineage tree)'].append(key)
-            else:
-                grouped_keys['other'].append(key)
-
-        widgetsWithShortcut_sorted = {}
-        for group, group_list in grouped_keys.items():
-            sorted_keys = natsorted(group_list)
-            widgetsWithShortcut_sorted.update({
-                k: widgetsWithShortcut[k]
-                for k in sorted_keys
-            })
-
-        widgetsWithShortcut = widgetsWithShortcut_sorted
-
+        self.new_hard_shortcuts = self._groupAndSortShortcuts(
+            self.new_hard_shortcuts, keep_at_beginning, grouped_keys
+        )
+            
         for row, (name, widget) in enumerate(widgetsWithShortcut.items(), start=row):
             button = widgets.PushButton(self, flat=True)
             try:
@@ -14765,11 +14784,25 @@ class ShortcutEditorDialog(QBaseDialog):
             entriesLayout.addWidget(label, row, 1)
             entriesLayout.addWidget(shortcutLineEdit, row, 2)
             self.shortcutLineEdits[name] = shortcutLineEdit
+            
+            warnConflictLabel = QLabel('')
+            self.shortcutLineEdits[name].warnConflictLabel = warnConflictLabel
+            entriesLayout.addWidget(warnConflictLabel, row, 4)
+            warnConflictLabel.setMinimumWidth(max_warn_width)
+            
+        for row, (name, shortcut) in enumerate(self.new_hard_shortcuts.items(), start=row):
+            button = widgets.PushButton(self, flat=True)
+            label = QLabel(f'{name}:')
+            lineEditTxt = QLabel(shortcut)
+            entriesLayout.addWidget(button, row, 0)
+            entriesLayout.addWidget(label, row, 1)
+            entriesLayout.addWidget(lineEditTxt, row, 2)
         
         entriesLayout.setColumnStretch(0, 0)
         entriesLayout.setColumnStretch(1, 0)
         entriesLayout.setColumnStretch(2, 1)
         entriesLayout.setColumnStretch(3, 0)
+        entriesLayout.setColumnStretch(4, 0)
 
         scrollAreaWidget.setLayout(entriesLayout)
         scrollArea.setWidget(scrollAreaWidget)
@@ -14784,6 +14817,29 @@ class ShortcutEditorDialog(QBaseDialog):
 
         self.setFont(fonts.font)
         self.setLayout(mainLayout)
+
+    def _groupAndSortShortcuts(self, shortcuts_dict, keep_at_beginning, grouped_keys):
+        for key in shortcuts_dict.keys():
+            found = False
+            if key in keep_at_beginning:
+                grouped_keys['keep_at_beginning'].append(key)
+            else:
+                for group_key in grouped_keys.keys():
+                    if group_key in key:
+                        grouped_keys[group_key].append(key)
+                        found = True
+                        break
+                if not found:
+                    grouped_keys['other'].append(key)
+
+        widgetsWithShortcut_sorted = {}
+        for group, group_list in grouped_keys.items():
+            sorted_keys = natsorted(group_list)
+            widgetsWithShortcut_sorted.update({
+                k: shortcuts_dict[k]
+                for k in sorted_keys
+            })
+        return widgetsWithShortcut_sorted
         
     def setShortcutLineEditEventFilter(self):
         sender = self.sender()
@@ -14818,12 +14874,35 @@ class ShortcutEditorDialog(QBaseDialog):
     def checkDuplicateShortcuts(self, text, sender=None):
         if sender is None:
             sender = self.sender()
+            
+        warnConflictLabel = getattr(sender, 'warnConflictLabel', None)
+        if warnConflictLabel is not None:
+            warnConflictLabel.setText('')
+            
+        if text == '':
+            return
+            
         for name, shortcutLineEdit in self.shortcutLineEdits.items():
             if shortcutLineEdit == sender:
                 continue
             if shortcutLineEdit.text() != text:
                 continue
             shortcutLineEdit.setText('')
+            warnConflictLabel = getattr(shortcutLineEdit, 'warnConflictLabel', None)
+            if warnConflictLabel is not None:
+                warnConflictLabel.setText(
+                    self.conflict_text_formatter(name)
+                )
+            break
+        for name, shortcut_txt in self.new_hard_shortcuts.items():
+            if shortcut_txt == text:
+                sender.setText('')
+                warnConflictLabel = getattr(sender, 'warnConflictLabel', None)
+                if warnConflictLabel is not None:
+                    warnConflictLabel.setText(
+                        self.conflict_text_formatter(name)
+                    )
+                break
     
     def warnInvalidKeySequenceDelObjWithLeftClick(self):
         txt = html_utils.paragraph(

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -96,6 +96,7 @@ from . import io
 from . import cca_functions
 from . import path
 from . import fonts
+from . import QtScoped
 
 POSITIVE_FLOAT_REGEX = float_regex(allow_negative=False)
 TREEWIDGET_STYLESHEET = _palettes.TreeWidgetStyleSheet()
@@ -14667,7 +14668,6 @@ class ShortcutEditorDialog(QBaseDialog):
         all_names = list(widgetsWithShortcut.keys()) + list(self.new_hard_shortcuts.keys())
         longest_name = max(all_names, key=len)
         self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name if not isinstance(name, tuple) else name[0]}</font>'
-        self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name if not isinstance(name, tuple) else name[0]}</font>'
         longest_conflict_text = self.conflict_text_formatter(longest_name)
 
         doc = QTextDocument()
@@ -14701,19 +14701,22 @@ class ShortcutEditorDialog(QBaseDialog):
         warnConflictLabel.setMinimumWidth(max_warn_width)
         self.delObjShortcutLineEdit.name = name
         self.shortcutLineEdits[name] = self.delObjShortcutLineEdit
+        self.delObjShortcutLineEdit.textChanged.connect(self.shortcutChanged)
+        self.delObjShortcutLineEdit.clicked.connect(self.setShortcutLineEditEventFilter)
+        self.delObjShortcutLineEdit.editingFinished.connect(self.releaseShortcutLineEditEventFilter)
                 
         row += 1
         name = 'Zoom out'
         button = widgets.PushButton(self, flat=True)
         label = QLabel('Zoom out:')
-        self.zoomShortcutLineEdit = widgets.ShortcutLineEdit()
+        self.zoomShortcutLineEdit = widgets.ShortcutLineEdit(allowMouseButtons=True)
         if zoomOutKeyValue is not None:
             zoomOutKeySequence = widgets.KeySequenceFromText(zoomOutKeyValue)
             self.zoomShortcutLineEdit.setText(zoomOutKeySequence.toString())
             self.zoomShortcutLineEdit.key = zoomOutKeyValue
-        self.zoomShortcutLineEdit.textChanged.connect(
-            self.checkDuplicateShortcuts
-        )
+        self.zoomShortcutLineEdit.textChanged.connect(self.shortcutChanged)
+        self.zoomShortcutLineEdit.clicked.connect(self.setShortcutLineEditEventFilter)
+        self.zoomShortcutLineEdit.editingFinished.connect(self.releaseShortcutLineEditEventFilter)
         entriesLayout.addWidget(button, row, 0)
         entriesLayout.addWidget(label, row, 1)
         entriesLayout.addWidget(self.zoomShortcutLineEdit, row, 2)
@@ -14773,7 +14776,8 @@ class ShortcutEditorDialog(QBaseDialog):
             shortcutLineEdit = widgets.ShortcutLineEdit(allowMouseButtons=True)
             if mouseBindings is not None and name in mouseBindings:
                 mouse_button = mouseBindings[name]
-                shortcutLineEdit.setText(f'Mouse {mouse_button.name}')
+                btn_name = QtScoped.mouse_button_name(mouse_button)
+                shortcutLineEdit.setText(f'Mouse {btn_name}')
                 isShortcutKeyPress = False
                 isShortcutMouseButton = True
             elif hasattr(widget, 'keyPressShortcut'):
@@ -14786,9 +14790,10 @@ class ShortcutEditorDialog(QBaseDialog):
                 isShortcutKeyPress = False
                 isShortcutMouseButton = False
                 
-            if isShortcutMouseButton: # always false wehn mouseBindings is None
+            if isShortcutMouseButton: # always false else mouseBindings is None
                 mouse_button = mouseBindings[name]
-                shortcutLineEdit.setText(f'Mouse {mouse_button.name}')
+                btn_name = QtScoped.mouse_button_name(mouse_button)
+                shortcutLineEdit.setText(f'Mouse {btn_name}')
             else:
                 shortcutLineEdit.setText(shortcut.toString())
                 

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -14667,6 +14667,7 @@ class ShortcutEditorDialog(QBaseDialog):
         all_names = list(widgetsWithShortcut.keys()) + list(self.new_hard_shortcuts.keys())
         longest_name = max(all_names, key=len)
         self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name if not isinstance(name, tuple) else name[0]}</font>'
+        self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name if not isinstance(name, tuple) else name[0]}</font>'
         longest_conflict_text = self.conflict_text_formatter(longest_name)
 
         doc = QTextDocument()
@@ -14919,33 +14920,52 @@ class ShortcutEditorDialog(QBaseDialog):
         if warnConflictLabel is not None:
             warnConflictLabel.setText('')
             
+            
+        if hasattr(sender, 'conflictWith'):
+            conflictWith = getattr(sender, 'conflictWith')
+            if conflictWith is not None:
+                for name_other, shortcutLineEdit in self.shortcutLineEdits.items():
+                    if name_other == conflictWith:
+                        warnConflictLabel_other = getattr(shortcutLineEdit, 'warnConflictLabel', None)
+                        if warnConflictLabel_other is not None:
+                            warnConflictLabel_other.setText('')
+                        shortcutLineEdit.conflictWith = None
+                
+        sender.conflictWith = None
+            
         if text == '':
             return
             
         name = sender.name
         group_updated = self.exclusivity_groups_reverse.get(name, 'other')
-        for name, shortcutLineEdit in self.shortcutLineEdits.items():
-            group = self.exclusivity_groups_reverse.get(name, 'other')
+        for name_other, shortcutLineEdit in self.shortcutLineEdits.items():
+            group = self.exclusivity_groups_reverse.get(name_other, 'other')
             if group != group_updated:
                 continue    
             if shortcutLineEdit == sender:
                 continue
             if shortcutLineEdit.text() != text:
                 continue
-            shortcutLineEdit.setText('')
+            # shortcutLineEdit.setText('')
             warnConflictLabel = getattr(shortcutLineEdit, 'warnConflictLabel', None)
             if warnConflictLabel is not None:
                 warnConflictLabel.setText(
                     self.conflict_text_formatter(name)
                 )
+            warnConflictLabel_sender = getattr(sender, 'warnConflictLabel', None)
+            if warnConflictLabel_sender is not None:
+                warnConflictLabel_sender.setText(
+                    self.conflict_text_formatter(name_other)
+                )
+            sender.conflictWith = name_other
             break
-        for name, shortcut_txt in self.new_hard_shortcuts.items():
+        for name_other, shortcut_txt in self.new_hard_shortcuts.items():
             if shortcut_txt == text:
-                sender.setText('')
+                # sender.setText('')
                 warnConflictLabel = getattr(sender, 'warnConflictLabel', None)
                 if warnConflictLabel is not None:
                     warnConflictLabel.setText(
-                        self.conflict_text_formatter(name)
+                        self.conflict_text_formatter(name_other)
                     )
                 break
     

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -101,6 +101,8 @@ POSITIVE_FLOAT_REGEX = float_regex(allow_negative=False)
 TREEWIDGET_STYLESHEET = _palettes.TreeWidgetStyleSheet()
 LISTWIDGET_STYLESHEET = _palettes.ListWidgetStyleSheet()
 BACKGROUND_RGBA = _palettes.get_disabled_colors()['Button']
+LINEEDIT_WARNING_STYLESHEET = _palettes.lineedit_warning_stylesheet()
+
 
 class ArgWidget:
     def __init__(self, name, type, widget, defaultVal, valueSetter, valueGetter, changeSig=None):
@@ -14634,7 +14636,8 @@ class ShortcutEditorDialog(QBaseDialog):
             zoomOutKeyValue: int=None,
             parent=None,
             mouseBindings: dict=None,
-            hard_shortcuts: dict=None
+            hard_shortcuts: dict=None,
+            highlighted_shortcut: str=None
         ):
         self.cancel = True
         super().__init__(parent)
@@ -14654,15 +14657,16 @@ class ShortcutEditorDialog(QBaseDialog):
         self.customShortcuts = {}
         self.shortcutLineEdits = {}
 
-        scrollArea = QScrollArea(self)
+        scrollArea = widgets.ScrollArea(self)
         scrollArea.setWidgetResizable(True)
+        self.scrollArea = scrollArea
         scrollAreaWidget = QWidget()
         entriesLayout = QGridLayout()
         
         conflict_prefix = 'Conflict with '
         all_names = list(widgetsWithShortcut.keys()) + list(self.new_hard_shortcuts.keys())
         longest_name = max(all_names, key=len)
-        self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name}</font>'
+        self.conflict_text_formatter = lambda name: f'<font color="red">{conflict_prefix}{name if not isinstance(name, tuple) else name[0]}</font>'
         longest_conflict_text = self.conflict_text_formatter(longest_name)
 
         doc = QTextDocument()
@@ -14694,7 +14698,9 @@ class ShortcutEditorDialog(QBaseDialog):
         self.delObjShortcutLineEdit.warnConflictLabel = warnConflictLabel
         entriesLayout.addWidget(warnConflictLabel, row, 4)
         warnConflictLabel.setMinimumWidth(max_warn_width)
-        
+        self.delObjShortcutLineEdit.name = name
+        self.shortcutLineEdits[name] = self.delObjShortcutLineEdit
+                
         row += 1
         name = 'Zoom out'
         button = widgets.PushButton(self, flat=True)
@@ -14711,6 +14717,7 @@ class ShortcutEditorDialog(QBaseDialog):
         entriesLayout.addWidget(label, row, 1)
         entriesLayout.addWidget(self.zoomShortcutLineEdit, row, 2)
         self.shortcutLineEdits[name] = self.zoomShortcutLineEdit
+        self.zoomShortcutLineEdit.name = name
         warnConflictLabel = QLabel('')
         self.zoomShortcutLineEdit.warnConflictLabel = warnConflictLabel
         entriesLayout.addWidget(warnConflictLabel, row, 4)
@@ -14720,7 +14727,10 @@ class ShortcutEditorDialog(QBaseDialog):
         
         # sort dicitonaries
         keep_at_beginning = ['Next', 'Previous']
+        if highlighted_shortcut is not None:
+            keep_at_beginning.insert(0, highlighted_shortcut)
 
+        # used for organizing the shortcuts into groups based on their names
         grouped_keys = {
             'keep_at_beginning': [],
             'other': [],
@@ -14730,6 +14740,19 @@ class ShortcutEditorDialog(QBaseDialog):
         widgetsWithShortcut = self._groupAndSortShortcuts(
             widgetsWithShortcut, keep_at_beginning, grouped_keys
         )
+        
+        # based on name, only check uniquness within these groups
+        # and the forbidden ones
+        exclusivity_groups = {
+            '(lineage tree)': [],
+            'other': [],
+        }
+        
+        exclusivity_groups['(lineage tree)'] = grouped_keys['(lineage tree)']
+        exclusivity_groups['other'] = grouped_keys['other'] + grouped_keys['keep_at_beginning']
+        self.exclusivity_groups_reverse = {
+            name: group for group, names in exclusivity_groups.items() for name in names
+        }
 
         grouped_keys = {
             'keep_at_beginning': [],
@@ -14783,6 +14806,7 @@ class ShortcutEditorDialog(QBaseDialog):
             entriesLayout.addWidget(button, row, 0)
             entriesLayout.addWidget(label, row, 1)
             entriesLayout.addWidget(shortcutLineEdit, row, 2)
+            shortcutLineEdit.name = name
             self.shortcutLineEdits[name] = shortcutLineEdit
             
             warnConflictLabel = QLabel('')
@@ -14790,9 +14814,21 @@ class ShortcutEditorDialog(QBaseDialog):
             entriesLayout.addWidget(warnConflictLabel, row, 4)
             warnConflictLabel.setMinimumWidth(max_warn_width)
             
-        for row, (name, shortcut) in enumerate(self.new_hard_shortcuts.items(), start=row):
+            if highlighted_shortcut is not None and name == highlighted_shortcut:
+                shortcutLineEdit.setStyleSheet(LINEEDIT_WARNING_STYLESHEET)
+            
+        row += 1
+        for row, (what, shortcut) in enumerate(self.new_hard_shortcuts.items(), start=row):
             button = widgets.PushButton(self, flat=True)
-            label = QLabel(f'{name}:')
+            if isinstance(what, str):
+                label = QLabel(f'{what}:')
+            else:
+                (name, widget) = what
+                try:
+                    button.setIcon(widget.icon())
+                except:
+                    pass
+                label = QLabel(f'{name}:')
             lineEditTxt = QLabel(shortcut)
             entriesLayout.addWidget(button, row, 0)
             entriesLayout.addWidget(label, row, 1)
@@ -14820,26 +14856,29 @@ class ShortcutEditorDialog(QBaseDialog):
 
     def _groupAndSortShortcuts(self, shortcuts_dict, keep_at_beginning, grouped_keys):
         for key in shortcuts_dict.keys():
+            actual_key = key
+            if isinstance(key, tuple):
+                key = key[0]
             found = False
             if key in keep_at_beginning:
-                grouped_keys['keep_at_beginning'].append(key)
+                grouped_keys['keep_at_beginning'].append(actual_key)
             else:
                 for group_key in grouped_keys.keys():
                     if group_key in key:
-                        grouped_keys[group_key].append(key)
+                        grouped_keys[group_key].append(actual_key)
                         found = True
                         break
                 if not found:
-                    grouped_keys['other'].append(key)
+                    grouped_keys['other'].append(actual_key)
 
-        widgetsWithShortcut_sorted = {}
+        widgets_with_shortcut_sorted = {}
         for group, group_list in grouped_keys.items():
-            sorted_keys = natsorted(group_list)
-            widgetsWithShortcut_sorted.update({
+            sorted_keys = natsorted(group_list, key=lambda x: x[0] if isinstance(x, tuple) else x)
+            widgets_with_shortcut_sorted.update({
                 k: shortcuts_dict[k]
                 for k in sorted_keys
             })
-        return widgetsWithShortcut_sorted
+        return widgets_with_shortcut_sorted
         
     def setShortcutLineEditEventFilter(self):
         sender = self.sender()
@@ -14882,7 +14921,12 @@ class ShortcutEditorDialog(QBaseDialog):
         if text == '':
             return
             
+        name = sender.name
+        group_updated = self.exclusivity_groups_reverse.get(name, 'other')
         for name, shortcutLineEdit in self.shortcutLineEdits.items():
+            group = self.exclusivity_groups_reverse.get(name, 'other')
+            if group != group_updated:
+                continue    
             if shortcutLineEdit == sender:
                 continue
             if shortcutLineEdit.text() != text:
@@ -14922,6 +14966,7 @@ class ShortcutEditorDialog(QBaseDialog):
             return
         
         self.shortcutLineEdits.pop('Zoom out')
+        self.shortcutLineEdits.pop('Delete object')
         self.cancel = False
         self.mouseBindings = dict()
         for name, shortcutLineEdit in self.shortcutLineEdits.items():
@@ -14956,7 +15001,8 @@ class ShortcutEditorDialog(QBaseDialog):
         super().closeEvent(event)
     
     def showEvent(self, event) -> None:
-        self.resize(int(self.width()*1.2), self.height())
+        minimumWidth = self.scrollArea.minimumWidthNoScrollbar()
+        self.resize(int(minimumWidth * 1.1), self.height())
         self.move(self.x(), 100)
 
 class SelectAcdcDfVersionToRestore(QBaseDialog):

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -14631,7 +14631,9 @@ class ShortcutEditorDialog(QBaseDialog):
             delObjectKey='',
             delObjectButton: Literal['Middle click', 'Left click']='Middle click',
             zoomOutKeyValue: int=None,
-            parent=None
+            parent=None,
+            mouseBindings: dict=None,
+            widgetsPercistantShortcuts: dict=None
         ):
         self.cancel = True
         super().__init__(parent)
@@ -14652,7 +14654,8 @@ class ShortcutEditorDialog(QBaseDialog):
         button = widgets.PushButton(self, flat=True)
         button.setIcon(QIcon(":del_obj_click.svg"))
         self.delObjShortcutLineEdit = widgets.ShortcutLineEdit(
-            allowModifiers=True, notAllowedModifier=Qt.AltModifier
+            allowModifiers=True, notAllowedModifier=Qt.AltModifier,
+            allowMouseButtons=True
         )
         if delObjectKey is not None:
             self.delObjShortcutLineEdit.setText(delObjectKey)
@@ -14684,6 +14687,39 @@ class ShortcutEditorDialog(QBaseDialog):
         self.shortcutLineEdits[name] = self.zoomShortcutLineEdit
         
         row += 1
+        
+        keep_at_beginning = ['Next', 'Previous']
+
+        grouped_keys = {
+            'keep_at_beginning': [],
+            'other': [],
+            '(lineage tree)': [],
+        }
+
+        grouped_keys = {
+            'keep_at_beginning': [],
+            'other': [],
+            '(lineage tree)': [],
+        }
+
+        for key in widgetsWithShortcut.keys():
+            if key in keep_at_beginning:
+                grouped_keys['keep_at_beginning'].append(key)
+            elif '(lineage tree)' in key:
+                grouped_keys['(lineage tree)'].append(key)
+            else:
+                grouped_keys['other'].append(key)
+
+        widgetsWithShortcut_sorted = {}
+        for group, group_list in grouped_keys.items():
+            sorted_keys = natsorted(group_list)
+            widgetsWithShortcut_sorted.update({
+                k: widgetsWithShortcut[k]
+                for k in sorted_keys
+            })
+
+        widgetsWithShortcut = widgetsWithShortcut_sorted
+
         for row, (name, widget) in enumerate(widgetsWithShortcut.items(), start=row):
             button = widgets.PushButton(self, flat=True)
             try:
@@ -14691,17 +14727,40 @@ class ShortcutEditorDialog(QBaseDialog):
             except:
                 pass
             label = QLabel(f'{name}:')
-            shortcutLineEdit = widgets.ShortcutLineEdit()
-            if hasattr(widget, 'keyPressShortcut'):
+            shortcutLineEdit = widgets.ShortcutLineEdit(allowMouseButtons=True)
+            if mouseBindings is not None and name in mouseBindings:
+                mouse_button = mouseBindings[name]
+                shortcutLineEdit.setText(f'Mouse {mouse_button.name}')
+                isShortcutKeyPress = False
+                isShortcutMouseButton = True
+            elif hasattr(widget, 'keyPressShortcut'):
                 shortcutLineEdit.key = widget.keyPressShortcut
                 shortcut = widgets.KeySequenceFromText(widget.keyPressShortcut)
                 isShortcutKeyPress = True
+                isShortcutMouseButton = False
             else:
                 shortcut = widget.shortcut()
                 isShortcutKeyPress = False
-            shortcutLineEdit.setText(shortcut.toString())
-            shortcutLineEdit.textChanged.connect(self.checkDuplicateShortcuts)
+                isShortcutMouseButton = False
+                
+            if isShortcutMouseButton: # always false wehn mouseBindings is None
+                mouse_button = mouseBindings[name]
+                shortcutLineEdit.setText(f'Mouse {mouse_button.name}')
+            else:
+                shortcutLineEdit.setText(shortcut.toString())
+                
+            shortcutLineEdit.textChanged.connect(self.shortcutChanged)
             shortcutLineEdit.isShortcutKeyPress = isShortcutKeyPress
+            shortcutLineEdit.isShortcutMouseButton = isShortcutMouseButton
+            # trigger when clicked
+            shortcutLineEdit.clicked.connect(
+                self.setShortcutLineEditEventFilter
+            )
+            # clean up when focus is lost
+            shortcutLineEdit.editingFinished.connect(
+                self.releaseShortcutLineEditEventFilter
+            )
+            
             entriesLayout.addWidget(button, row, 0)
             entriesLayout.addWidget(label, row, 1)
             entriesLayout.addWidget(shortcutLineEdit, row, 2)
@@ -14725,10 +14784,42 @@ class ShortcutEditorDialog(QBaseDialog):
 
         self.setFont(fonts.font)
         self.setLayout(mainLayout)
+        
+    def setShortcutLineEditEventFilter(self):
+        sender = self.sender()
+        previous = getattr(self, '_activeShortcutLineEdit', None)
+        if previous is not None and previous is not sender:
+            QApplication.instance().removeEventFilter(previous)
+            previous.isRecording = False
+
+        QApplication.instance().installEventFilter(sender)
+        sender.isRecording = True
+        self._activeShortcutLineEdit = sender
+
+    def releaseShortcutLineEditEventFilter(self):
+        sender = self.sender()
+        QApplication.instance().removeEventFilter(sender)
+        sender.isRecording = False
+        if getattr(self, '_activeShortcutLineEdit', None) is sender:
+            self._activeShortcutLineEdit = None
+        
+    def shortcutChanged(self, text):
+        sender = self.sender()
+        self.checkDuplicateShortcuts(text, sender=sender)
     
-    def checkDuplicateShortcuts(self, text):
+    def updateMouseBindings(self, text, sender=None):
+        if sender is None:
+            sender = self.sender()
+        if text.startswith('Mouse '):
+            sender.isShortcutMouseButton = True
+        else:
+            sender.isShortcutMouseButton = False
+    
+    def checkDuplicateShortcuts(self, text, sender=None):
+        if sender is None:
+            sender = self.sender()
         for name, shortcutLineEdit in self.shortcutLineEdits.items():
-            if shortcutLineEdit == self.sender():
+            if shortcutLineEdit == sender:
                 continue
             if shortcutLineEdit.text() != text:
                 continue
@@ -14753,9 +14844,15 @@ class ShortcutEditorDialog(QBaseDialog):
         
         self.shortcutLineEdits.pop('Zoom out')
         self.cancel = False
+        self.mouseBindings = dict()
         for name, shortcutLineEdit in self.shortcutLineEdits.items():
             text = shortcutLineEdit.text()
-            if shortcutLineEdit.isShortcutKeyPress:
+            if shortcutLineEdit.isShortcutMouseButton:
+                button_name = text.split('Mouse ')[-1]
+                button = Qt.MouseButton[button_name]
+                self.mouseBindings[name] = button
+                self.customShortcuts[name] = (text, button)
+            elif shortcutLineEdit.isShortcutKeyPress:
                 self.customShortcuts[name] = (text, shortcutLineEdit.key)
             else:
                 self.customShortcuts[name] = (
@@ -14770,6 +14867,14 @@ class ShortcutEditorDialog(QBaseDialog):
         self.zoomOutKeyValue = self.zoomShortcutLineEdit.key
         
         self.close()
+        
+    def closeEvent(self, event):
+        active = getattr(self, '_activeShortcutLineEdit', None)
+        if active is not None:
+            QApplication.instance().removeEventFilter(active)
+            active.isRecording = False
+            self._activeShortcutLineEdit = None
+        super().closeEvent(event)
     
     def showEvent(self, event) -> None:
         self.resize(int(self.width()*1.2), self.height())

--- a/cellacdc/config.py
+++ b/cellacdc/config.py
@@ -280,3 +280,11 @@ def preprocess_ini_items_to_recipe(ini_items):
 
 PREPROCESS_MAPPER = preprocessing_mapper()
 PREPROCESS_INIT_MAPPER = preprocessing_init_func_mapper()
+if GUI_INSTALLED:
+    from qtpy.QtCore import Qt
+    STANDARD_MOUSE_BUTTONS = (
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.RightButton,
+        Qt.MouseButton.MiddleButton,
+        Qt.MouseButton.NoButton,
+    )

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -1482,7 +1482,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.whitelistIDsButton.action = editToolBar.addWidget(
             self.whitelistIDsButton
         )
-        self.whitelistIDsButton.setShortcut('Ctrl+K')
+        self.whitelistIDsButton.setShortcut('Ctrl+Shift+W')
         self.checkableButtons.append(self.whitelistIDsButton)
         self.checkableQButtonsGroup.addButton(self.whitelistIDsButton)
         self.LeftClickButtons.append(self.whitelistIDsButton)
@@ -1648,8 +1648,20 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.annotateToolbar.setVisible(False)
         
     def gui_editRightClickMenuButtons(self):
+        NAMES_TO_IGNORE_ERROR = (
+            "Toggle max z projection",
+            "Previous",
+            "Next"
+        )
+        
+        
         for name, button in self.widgetsWithShortcut.items():
-            self._setupRightClickMenuOnButton(button)
+            if name in NAMES_TO_IGNORE_ERROR:
+                continue
+            res = self._setupRightClickMenuOnButton(button)
+            if res[0] is False or res[1] != 1:
+                print(f"Error setting up right click menu for: {name}")
+                print(f"Number of associated widgets: {res[1]}")
             menu = button.rightClickMenu
             action = QAction('Set shortcut...', self)
             action.triggered.connect(
@@ -1658,36 +1670,54 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             menu.addAction(action)
             
         for name, button in self.keepToolActiveNames.items():
-            self._setupRightClickMenuOnButton(button)
+            if name in NAMES_TO_IGNORE_ERROR:
+                continue
+            res = self._setupRightClickMenuOnButton(button)
+            if res[0] is False or res[1] != 1:
+                print(f"Error setting up right click menu for: {name}")
+                print(f"Number of associated widgets: {res[1]}")
             menu = button.rightClickMenu
             action = self.keepToolActiveActions[name]
             menu.addAction(action)
             
         for name, button in self.applyToolNewFrameButtons.items():
-            self._setupRightClickMenuOnButton(button)
+            if name in NAMES_TO_IGNORE_ERROR:
+                continue
+            res = self._setupRightClickMenuOnButton(button)
+            if res[0] is False or res[1] != 1:
+                print(f"Error setting up right click menu for: {name}")
+                print(f"Number of associated widgets: {res[1]}")
             menu = button.rightClickMenu
             action = self.applyToolNewFrameActions[name]
             menu.addAction(action)
             
     def _setupRightClickMenuOnButton(self, target):
         if hasattr(target, 'rightClickMenu') and target.rightClickMenu is not None:
-            return
+            return True, 1
         
         menu = QMenu(self)
         target.rightClickMenu = menu
+        widgets = None
         if isinstance(target, QAction):
-            widgets = None
             if hasattr(target, 'associatedWidgets'):
                 widgets = target.associatedWidgets()
             elif hasattr(target, 'widgetsforAction'):
                 widgets = target.widgetsforAction()
-            if widgets is None:
-                printl("Warning: Could not find associated widgets for QAction", target)
+            elif hasattr(target, 'associatedObjects'):
+                objects = target.associatedObjects()
+                widgets = [
+                    obj for obj in objects
+                    if isinstance(obj, QToolButton) and obj is not self
+                    and obj is not target.parent
+                    ]
+            if widgets is None or len(widgets) == 0:
+                return False, len(widgets)
             else:    
                 for w in widgets:
                     self._installRightClickFilter(w, menu)
         else:
             self._installRightClickFilter(target, menu)
+        return True, len(widgets) if widgets is not None else 1
 
     def _installRightClickFilter(self, widget: QWidget, menu: QMenu):
         if getattr(widget, 'installedEventFilter', False):

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -124,34 +124,6 @@ custom_annot_path = os.path.join(settings_folderpath, 'custom_annotations.json')
 shortcut_filepath = os.path.join(settings_folderpath, 'shortcuts.ini')
 
 # Hard-coded shortcuts that are reserved for non-customizable actions.
-FORBIDDEN_SHORTCUTS = {
-    'Ctrl+Shift+N': 'New Window',
-    'Ctrl+N': 'New Segmentation File',
-    'Ctrl+O': 'Load Folder',
-    'Shift+P': 'Load Different Position',
-    'Ctrl+Shift+S': 'Save as',
-    'Ctrl+Shift+V': 'Export to Video',
-    'Ctrl+Shift+I': 'Export to Image',
-    'Ctrl+Alt+S': 'Save',
-    'Ctrl+S': 'Save Only Segmentation Masks',
-    'Ctrl+Z': 'Undo',
-    'Ctrl+Y': 'Redo',
-    'Ctrl+Shift+A': 'Autopilot',
-    'Ctrl+F': 'Find ID',
-    'Ctrl+T': 'Track current frame with real-time tracker',
-    'Alt+Shift+T': 'Track multiple frames with selected tracker',
-    'Ctrl+K': 'Customize keyboard shortcuts',
-    'Ctrl+M': 'Show mirrored cursor on images',
-    'Ctrl+Shift+P': 'Edit cell cycle annotations',
-    'Ctrl+P': 'View cell cycle annotations',
-    'Shift+S': 'Randomly shuffle colormap',
-    'Alt+Shift+S': 'Greedily shuffle colormap',
-    'Alt+Shift+P': 'Pre-processing',
-    'Alt+Shift+C': 'Combine channels and segmentation files',
-    'Ctrl+L': 'Relabel IDs sequentially',
-    'Left': 'Go to previous frame',
-    'Right': 'Go to next frame',
-}
 
 _font = QFont()
 _font.setPixelSize(11)
@@ -235,6 +207,20 @@ def resetViewRange(func):
         QTimer.singleShot(200, self.resetRange)
         return result
     return inner_function
+
+class RightClickMenuFilter(QObject):
+    """Install on any widget to show a custom QMenu on right-click,
+    without altering the widget's normal left-click behavior."""
+    
+    def eventFilter(self, obj, event):
+        if (event.type() == QEvent.MouseButtonPress 
+                and event.button() == Qt.RightButton):
+            menu = getattr(obj, 'rightClickMenu', None)
+            if menu is not None:
+                menu.exec_(QCursor.pos())
+                return True  # swallow the event — don't let it fall through
+                             # to the button's normal press handling
+        return False  # everything else: pass through untouched
       
 class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
              gui_combine.CombineGuiElements, 
@@ -428,6 +414,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.gui_createQuickSettingsWidgets()
         self.setTooltips()
         self.gui_populateToolSettingsMenu()
+        self.gui_editRightClickMenuButtons()
 
         self.autoSaveGarbageWorkers = []
         self.autoSaveActiveWorkers = []
@@ -1659,6 +1646,60 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.annotateToolbar.addAction(self.addCustomAnnotationAction)
         self.annotateToolbar.addAction(self.viewAllCustomAnnotAction)
         self.annotateToolbar.setVisible(False)
+        
+    def gui_editRightClickMenuButtons(self):
+        for name, button in self.widgetsWithShortcut.items():
+            print(f"Setting up right-click menu for button: {name}")
+            # if name in FORBIDDEN_SHORTCUTS.values():
+            #     continue
+            self._setupRightClickMenuOnButton(button)
+            menu = button.rightClickMenu
+            action = QAction('Set shortcut...', self)
+            action.triggered.connect(
+                lambda z, name=name: self.editShortcuts_cb(highlighted_shortcut=name)
+            )
+            menu.addAction(action)
+            
+        for name, button in self.keepToolActiveNames.items():
+            self._setupRightClickMenuOnButton(button)
+            menu = button.rightClickMenu
+            action = self.keepToolActiveActions[name]
+            menu.addAction(action)
+            
+        for name, button in self.applyToolNewFrameButtons.items():
+            self._setupRightClickMenuOnButton(button)
+            menu = button.rightClickMenu
+            action = self.applyToolNewFrameActions[name]
+            menu.addAction(action)
+            
+    def _setupRightClickMenuOnButton(self, target):
+        if hasattr(target, 'rightClickMenu') and target.rightClickMenu is not None:
+            return
+        
+        menu = QMenu(self)
+        target.rightClickMenu = menu
+        if isinstance(target, QAction):
+            widgets = None
+            if hasattr(target, 'associatedWidgets'):
+                widgets = target.associatedWidgets()
+            elif hasattr(target, 'widgetsforAction'):
+                widgets = target.widgetsforAction()
+            if widgets is None:
+                printl("Warning: Could not find associated widgets for QAction", target)
+            else:    
+                for w in widgets:
+                    self._installRightClickFilter(w, menu)
+
+        self._installRightClickFilter(target, menu)
+
+    def _installRightClickFilter(self, widget: QWidget, menu: QMenu):
+        if getattr(widget, 'installedEventFilter', False):
+            return
+        if not hasattr(self, '_rightClickFilterObj'):
+            self._rightClickFilterObj = RightClickMenuFilter()
+        widget.installEventFilter(self._rightClickFilterObj)
+        widget.installedEventFilter = True
+        widget.rightClickMenu = menu
 
     def gui_createLazyLoader(self):
         if not self.lazyLoader is None:
@@ -2537,7 +2578,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             keepToolActiveNames[toolName] = button
         
         keepToolActiveNames = dict(natsorted(keepToolActiveNames.items()))
-        
+        self.keepToolActiveNames = keepToolActiveNames
         applyToNewFrameNames = {
             'Segmenting for lost IDs': self.segForLostIDsButton,
             'Delete bordering objects': self.delBorderObjAction.button,
@@ -27407,7 +27448,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         with open(shortcut_filepath, 'w') as ini:
             cp.write(ini)
     
-    def editShortcuts_cb(self):
+    def editShortcuts_cb(self, highlighted_shortcut=None):
+        if hasattr(self, 'showingShortcutEditorDialog') and self.showingShortcutEditorDialog:
+            return
+        self.showingShortcutEditorDialog = True
+            
         if is_mac:
             delObjKeySequenceText = 'Ctrl'
             delObjButtonText = 'Left click'
@@ -27428,6 +27473,35 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 'Left click' if delObjQtButton == Qt.MouseButton.LeftButton
                 else 'Middle click'
             )
+
+        hard_shortcuts = {
+            'Ctrl+Shift+N': ('New Window', self.newWindowAction),
+            'Ctrl+N': ('New Segmentation File', self.newAction),
+            'Ctrl+O': ('Load Folder', self.openFolderAction),
+            'Shift+P': ('Load Different Position', self.loadPosAction),
+            'Ctrl+Shift+S': ('Save as', self.saveAsAction),
+            'Ctrl+Shift+V': ('Export to Video', self.exportToVideoAction),
+            'Ctrl+Shift+I': ('Export to Image', self.exportToImageAction),
+            'Ctrl+Alt+S': ('Save', self.saveAction),
+            'Ctrl+S': ('Save Only Segmentation Masks', self.quickSaveAction),
+            'Ctrl+Z': ('Undo', self.undoAction),
+            'Ctrl+Y': ('Redo', self.redoAction),
+            'Ctrl+Shift+A': ('Autopilot', self.autoPilotButton),
+            'Ctrl+F': ('Find ID', self.findIdAction),
+            'Ctrl+T': ('Track current frame with real-time tracker', self.repeatTrackingMenuAction),
+            'Alt+Shift+T': ('Track multiple frames with selected tracker', self.repeatTrackingVideoAction),
+            'Ctrl+K': ('Customize keyboard shortcuts', self.editShortcutsAction),
+            'Ctrl+M': ('Show mirrored cursor on images', self.showMirroredCursorAction),
+            'Ctrl+Shift+P': ('Edit cell cycle annotations', self.manuallyEditCcaAction),
+            'Ctrl+P': ('View cell cycle annotations', self.viewCcaTableAction),
+            'Shift+S': ('Randomly shuffle colormap', self.shuffleCmapAction),
+            'Alt+Shift+S': ('Greedily shuffle colormap', self.greedyShuffleCmapAction),
+            'Alt+Shift+P': ('Pre-processing', self.preprocessAction),
+            'Alt+Shift+C': ('Combine channels and segmentation files', self.combineChannelsAction),
+            'Ctrl+L': ('Relabel IDs sequentially', self.relabelSequentialAction),
+            'Left': 'Go to previous frame',
+            'Right': 'Go to next frame',
+        }
             
         win = apps.ShortcutEditorDialog(
             self.widgetsWithShortcut, 
@@ -27436,16 +27510,19 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             zoomOutKeyValue=self.zoomOutKeyValue,
             parent=self,
             mouseBindings=self.mouseBindings,
-            hard_shortcuts=FORBIDDEN_SHORTCUTS
+            hard_shortcuts=hard_shortcuts,
+            highlighted_shortcut=highlighted_shortcut
         )
         win.exec_()
         if win.cancel:
+            self.showingShortcutEditorDialog = False
             return
 
         self.mouseBindings = win.mouseBindings
         self.delObjAction = win.delObjAction
         self.zoomOutKeyValue = win.zoomOutKeyValue
         self.setShortcuts(win.customShortcuts)
+        self.showingShortcutEditorDialog = False
             
     def toggleOverlayColorButton(self, checked=True):
         self.mousePressColorButton(None)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -100,7 +100,7 @@ from . import exec_time
 from .plot import imshow
 from . import gui_utils
 from . import gui_combine
-
+from .config import STANDARD_MOUSE_BUTTONS
 np.seterr(invalid='ignore')
 
 if os.name == 'nt':
@@ -338,6 +338,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.whyNavigateDisabled = set()
         self.autoSaveTimer = QTimer()
         self.dirtyPointsLayerTableEndNames = set()
+        self.mouseBindings = dict()
+        self.defaultMouseShortcuts = dict()
+        self.widgetsPersistentShortcut = dict()
         
         self._setup_vars_combine()
         if 'autoSaveIntevalValue' not in self.df_settings.index:
@@ -1474,10 +1477,11 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.binCellButton = QToolButton(self)
         self.binCellButton.setIcon(QIcon(":bin.svg"))
         self.binCellButton.setCheckable(True)
-        # self.binCellButton.setShortcut('R')
         self.binCellButton.action = editToolBar.addWidget(self.binCellButton)
         self.checkableButtons.append(self.binCellButton)
         self.checkableQButtonsGroup.addButton(self.binCellButton)
+        self.binCellButton.setShortcut('Ctrl+E')
+        self.widgetsWithShortcut['Exclude cell from analysis'] = self.binCellButton
         # self.functionsNotTested3D.append(self.binCellButton)
 
         self.manualTrackingButton = QToolButton(self)
@@ -2700,8 +2704,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         # self.reloadAction = QAction(
         #     QIcon(":reload.svg"), "Reload segmentation file", self
         # )
+        
         self.nextAction = QAction('Next', self)
+        self.defaultMouseShortcuts['Next'] = Qt.MouseButton.XButton2
+        self.widgetsWithShortcut['Next'] = self.nextAction
+        self.widgetsPersistentShortcut['Next'] = Qt.Key_Right
+
         self.prevAction = QAction('Previous', self)
+        self.defaultMouseShortcuts['Previous'] = Qt.MouseButton.XButton1
+        self.widgetsWithShortcut['Previous'] = self.prevAction
+        self.widgetsPersistentShortcut['Previous'] = Qt.Key_Left
+        
         self.showInExplorerAction = QAction(
             QIcon(":drawer.svg"), f"&{self.openFolderText}", self
         )
@@ -2720,8 +2733,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.quickSaveAction.setShortcut('Ctrl+S')
         self.undoAction.setShortcut('Ctrl+Z')
         self.redoAction.setShortcut('Ctrl+Y')
-        self.nextAction.setShortcut(Qt.Key_Right)
-        self.prevAction.setShortcut(Qt.Key_Left)
+
         self.addAction(self.nextAction)
         self.addAction(self.prevAction)
         # Help tips
@@ -3079,6 +3091,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         # self.imgGradLabelsAlphaUpAction = QAction(self)
         # self.imgGradLabelsAlphaUpAction.setVisible(False)
         # self.imgGradLabelsAlphaUpAction.setShortcut('Ctrl+Up')
+        
+        self.MaxProjToggleAction = QAction(self)
+        self.MaxProjToggleAction.triggered.connect(
+            self.maxProjToggleActionTriggered
+        )
+        # hide action
+        self.MaxProjToggleAction.setShortcutContext(Qt.ShortcutContext.WindowShortcut)
+        self.addAction(self.MaxProjToggleAction)
+        # self.MaxProjToggleAction.setVisible(False)
+        self.MaxProjToggleAction.setShortcut('Alt+X')
+        self.widgetsWithShortcut['Toggle max z projection'] = self.MaxProjToggleAction
     
     def gui_updateSwitchColorSchemeActionText(self):
         if self._colorScheme == 'dark':
@@ -7419,6 +7442,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             activeRois.append(getattr(self, 'zoomRectItem', None))
 
         activeRois = [roi for roi in activeRois if self.gui_isActiveInterceptRoi(roi)]
+        
+        # check that no other button was clicked
+        
+        click_shortcut_action = ''
+        if event.button() not in STANDARD_MOUSE_BUTTONS:
+            for name, button in self.mouseBindings.items():
+                if button == event.button():
+                    click_shortcut_action = name
+                    self.mousePressEvent(event)
+                    break
+                    
 
         if any(self.gui_isHoveringRoiHandle(roi) for roi in activeRois):
             event.ignore()
@@ -7676,8 +7710,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             event.ignore()
             return
 
-        isAllowedActionViewer = (canAddPoint or canRuler)
-        
+        isAllowedActionViewer = (
+            canAddPoint 
+            or canRuler
+            or click_shortcut_action == "Previous"
+            or click_shortcut_action == "Next"
+        )
         if mode == 'Viewer' and not isAllowedActionViewer:
             self.startBlinkingModeCB()
             event.ignore()
@@ -15778,6 +15816,25 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             pos = self.resizeBottomLayoutLine.mapFromGlobal(event.globalPos())
             if pos.y()>=0:
                 self.gui_raiseBottomLayoutContextMenu(event)
+        if event.button() not in STANDARD_MOUSE_BUTTONS:
+            for name, button in self.mouseBindings.items():
+                if not button == event.button():
+                    continue
+                action = self.widgetsWithShortcut[name]
+                success = False
+                if not success:
+                    try:
+                        action.click()
+                        success = True
+                    except:
+                        pass
+                if not success:
+                    try:
+                        action.trigger()
+                        success = True
+                    except:
+                        pass
+                return
         return super().mousePressEvent(event)
         
     def zoomBottomLayoutActionTriggered(self, checked):
@@ -16015,6 +16072,25 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         if ev.key() == Qt.Key_End:
             self.onKeyEnd()
+            
+        for name, key in self.widgetsPersistentShortcut.items():
+            if not key == ev.key():
+                continue
+            action = self.widgetsWithShortcut[name]
+            success = False
+            if not success:
+                try:
+                    action.click()
+                    success = True
+                except:
+                    pass
+            if not success:
+                try:
+                    action.trigger()
+                    success = True
+                except:
+                    pass
+            break
         
         modifiers = ev.modifiers()
         isAltModifier = modifiers == Qt.AltModifier
@@ -21319,7 +21395,23 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.setOverlayLabelsItems()
             self.drawPointsLayers(computePointsLayers=False)
             self.zSliceScrollBarStartedMoving = False
-            self.highlightSearchedID(self.highlightedID, force=True) 
+            self.highlightSearchedID(self.highlightedID, force=True)
+            
+    def maxProjToggleActionTriggered(self):
+        posData = self.data[self.pos_i]
+        if posData.SizeZ <= 1:
+            return
+        
+        zProjHow_curr = self.zProjComboBox.currentText()
+        if not hasattr(self, 'setMaxProjToggleOld') and zProjHow_curr == 'single z-slice':
+            self.setMaxProjToggleOld = 'max z-projection'
+
+
+        if zProjHow_curr == 'single z-slice':
+            self.zProjComboBox.setCurrentText(self.setMaxProjToggleOld)
+        else:
+            self.setMaxProjToggleOld = zProjHow_curr
+            self.zProjComboBox.setCurrentText('single z-slice')
 
     def zSliceScrollBarReleased(self):
         self.clearTempBrushImage()
@@ -27192,16 +27284,28 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         shortcuts = {}
         for name, widget in self.widgetsWithShortcut.items():
             if name not in cp.options('keyboard.shortcuts'):
-                if hasattr(widget, 'keyPressShortcut'):
-                    key = widget.keyPressShortcut
-                    shortcut = widgets.KeySequenceFromText(key)
+                if name in self.defaultMouseShortcuts:
+                    button = self.defaultMouseShortcuts[name]
+                    shortcut_text = f'Mouse {button.name}' # for easier finding keep this pattern
+                    self.mouseBindings[name] = button
+                    shortcut = button
                 else:
-                    shortcut = widget.shortcut()
-                shortcut_text = shortcut.toString()
+                    if hasattr(widget, 'keyPressShortcut'):
+                        key = widget.keyPressShortcut
+                        shortcut = widgets.KeySequenceFromText(key)
+                    else:
+                        shortcut = widget.shortcut()
+                    shortcut_text = shortcut.toString()
                 cp['keyboard.shortcuts'][name] = shortcut_text
             else:
                 shortcut_text = cp['keyboard.shortcuts'][name]
-                shortcut = widgets.KeySequenceFromText(shortcut_text)
+                if shortcut_text.startswith('Mouse '):
+                    button_name = shortcut_text.split('Mouse ')[-1]
+                    button = Qt.MouseButton[button_name]
+                    self.mouseBindings[name] = button
+                    shortcut = button
+                else:
+                    shortcut = widgets.KeySequenceFromText(shortcut_text)
             
             shortcuts[name] = (shortcut_text, shortcut)
         self.setShortcuts(shortcuts, save=False)
@@ -27211,7 +27315,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     def setShortcuts(self, shortcuts: dict, save=True):
         for name, (text, shortcut) in shortcuts.items():
             widget = self.widgetsWithShortcut[name]
-            if shortcut is None:
+            if shortcut is None or text.startswith('Mouse '):
                 shortcut = QKeySequence()
             if hasattr(widget, 'keyPressShortcut'):
                 widget.keyPressShortcut = shortcut
@@ -27300,12 +27404,14 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             delObjectKey=delObjKeySequenceText,
             delObjectButton=delObjButtonText,
             zoomOutKeyValue=self.zoomOutKeyValue,
-            parent=self
+            parent=self,
+            mouseBindings=self.mouseBindings,
         )
         win.exec_()
         if win.cancel:
             return
 
+        self.mouseBindings = win.mouseBindings
         self.delObjAction = win.delObjAction
         self.zoomOutKeyValue = win.zoomOutKeyValue
         self.setShortcuts(win.customShortcuts)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -1649,9 +1649,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
     def gui_editRightClickMenuButtons(self):
         for name, button in self.widgetsWithShortcut.items():
-            print(f"Setting up right-click menu for button: {name}")
-            # if name in FORBIDDEN_SHORTCUTS.values():
-            #     continue
             self._setupRightClickMenuOnButton(button)
             menu = button.rightClickMenu
             action = QAction('Set shortcut...', self)
@@ -1689,8 +1686,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             else:    
                 for w in widgets:
                     self._installRightClickFilter(w, menu)
-
-        self._installRightClickFilter(target, menu)
+        else:
+            self._installRightClickFilter(target, menu)
 
     def _installRightClickFilter(self, widget: QWidget, menu: QMenu):
         if getattr(widget, 'installedEventFilter', False):
@@ -15898,19 +15895,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 if not button == event.button():
                     continue
                 action = self.widgetsWithShortcut[name]
-                success = False
-                if not success:
-                    try:
-                        action.click()
-                        success = True
-                    except:
-                        pass
-                if not success:
-                    try:
-                        action.trigger()
-                        success = True
-                    except:
-                        pass
+                if hasattr(action, 'click'):
+                    action.click()
+                elif hasattr(action, 'trigger'):
+                    action.trigger()
                 return
         return super().mousePressEvent(event)
         
@@ -16155,18 +16143,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 continue
             action = self.widgetsWithShortcut[name]
             success = False
-            if not success:
-                try:
-                    action.click()
-                    success = True
-                except:
-                    pass
-            if not success:
-                try:
-                    action.trigger()
-                    success = True
-                except:
-                    pass
+            if hasattr(action, 'click'):
+                action.click()
+            elif hasattr(action, 'trigger'):
+                action.trigger()
             break
         
         modifiers = ev.modifiers()

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -123,6 +123,36 @@ RP_OPT_PERC_CUTOUT_MAX = 0.3 # th for trying to do local updates to regionprops,
 custom_annot_path = os.path.join(settings_folderpath, 'custom_annotations.json')
 shortcut_filepath = os.path.join(settings_folderpath, 'shortcuts.ini')
 
+# Hard-coded shortcuts that are reserved for non-customizable actions.
+FORBIDDEN_SHORTCUTS = {
+    'Ctrl+Shift+N': 'New Window',
+    'Ctrl+N': 'New Segmentation File',
+    'Ctrl+O': 'Load Folder',
+    'Shift+P': 'Load Different Position',
+    'Ctrl+Shift+S': 'Save as',
+    'Ctrl+Shift+V': 'Export to Video',
+    'Ctrl+Shift+I': 'Export to Image',
+    'Ctrl+Alt+S': 'Save',
+    'Ctrl+S': 'Save Only Segmentation Masks',
+    'Ctrl+Z': 'Undo',
+    'Ctrl+Y': 'Redo',
+    'Ctrl+Shift+A': 'Autopilot',
+    'Ctrl+F': 'Find ID',
+    'Ctrl+T': 'Track current frame with real-time tracker',
+    'Alt+Shift+T': 'Track multiple frames with selected tracker',
+    'Ctrl+K': 'Customize keyboard shortcuts',
+    'Ctrl+M': 'Show mirrored cursor on images',
+    'Ctrl+Shift+P': 'Edit cell cycle annotations',
+    'Ctrl+P': 'View cell cycle annotations',
+    'Shift+S': 'Randomly shuffle colormap',
+    'Alt+Shift+S': 'Greedily shuffle colormap',
+    'Alt+Shift+P': 'Pre-processing',
+    'Alt+Shift+C': 'Combine channels and segmentation files',
+    'Ctrl+L': 'Relabel IDs sequentially',
+    'Left': 'Go to previous frame',
+    'Right': 'Go to next frame',
+}
+
 _font = QFont()
 _font.setPixelSize(11)
 
@@ -27406,6 +27436,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             zoomOutKeyValue=self.zoomOutKeyValue,
             parent=self,
             mouseBindings=self.mouseBindings,
+            hard_shortcuts=FORBIDDEN_SHORTCUTS
         )
         win.exec_()
         if win.cancel:

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -1711,7 +1711,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     and obj is not target.parent
                     ]
             if widgets is None or len(widgets) == 0:
-                return False, len(widgets)
+                return False, len(widgets) if widgets is not None else 0
             else:    
                 for w in widgets:
                     self._installRightClickFilter(w, menu)
@@ -27458,13 +27458,16 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 )
             self.delObjToolAction.setChecked(True)
             self.delObjAction = delObjKeySequence, delObjQtButton
-              
         shortcuts = {}
         for name, widget in self.widgetsWithShortcut.items():
             if name not in cp.options('keyboard.shortcuts'):
                 if name in self.defaultMouseShortcuts:
                     button = self.defaultMouseShortcuts[name]
-                    shortcut_text = f'Mouse {button.name}' # for easier finding keep this pattern
+                    if PYQT6:
+                        btn_name = button.name
+                    else:
+                        btn_name = QtScoped.mouse_button_name(button)
+                    shortcut_text = f'Mouse {btn_name}' # for easier finding keep this pattern
                     self.mouseBindings[name] = button
                     shortcut = button
                 else:
@@ -27479,7 +27482,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 shortcut_text = cp['keyboard.shortcuts'][name]
                 if shortcut_text.startswith('Mouse '):
                     button_name = shortcut_text.split('Mouse ')[-1]
-                    button = Qt.MouseButton[button_name]
+                    if PYQT6:
+                        button = Qt.MouseButton[button_name]
+                    else:
+                        button =  getattr(Qt, button_name)
                     self.mouseBindings[name] = button
                     shortcut = button
                 else:

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -3829,7 +3829,6 @@ def QKeyEventToString(event: QKeyEvent, notAllowedModifier=None):
 
 class ShortcutLineEdit(QLineEdit):
     clicked = Signal()
-    editingFinished = Signal()
     def __init__(
             self, parent=None, allowModifiers=False, notAllowedModifier=None,
             allowMouseButtons=False
@@ -3844,7 +3843,7 @@ class ShortcutLineEdit(QLineEdit):
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Type.MouseButtonPress:
             button = event.button()
-            if button not in STANDARD_MOUSE_BUTTONS:
+            if self._allowMouseButtons and button not in STANDARD_MOUSE_BUTTONS:
                 self.setText(f'Mouse {button.name}')
                 return True  # consume: don't let it reach the widget under the cursor
         return super().eventFilter(obj, event)  # False for everything else -> passes through normally
@@ -3898,9 +3897,9 @@ class ShortcutLineEdit(QLineEdit):
         super().focusInEvent(event)
         self.clicked.emit()  # or call your filter-install logic directly
 
-    def focusOutEvent(self, event):
-        self.editingFinished.emit()  # or call your filter-release logic directly
-        super().focusOutEvent(event)
+    # def focusOutEvent(self, event):
+    #     self.editingFinished.emit()  # or call your filter-release logic directly
+    #     super().focusOutEvent(event)
         
     def sizeHint(self):
         size_hint = super().sizeHint()

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -3844,7 +3844,8 @@ class ShortcutLineEdit(QLineEdit):
         if event.type() == QEvent.Type.MouseButtonPress:
             button = event.button()
             if self._allowMouseButtons and button not in STANDARD_MOUSE_BUTTONS:
-                self.setText(f'Mouse {button.name}')
+                btn_name = QtScoped.mouse_button_name(button)
+                self.setText(f'Mouse {btn_name}')
                 return True  # consume: don't let it reach the widget under the cursor
         return super().eventFilter(obj, event)  # False for everything else -> passes through normally
     
@@ -3858,6 +3859,9 @@ class ShortcutLineEdit(QLineEdit):
         
         super().setText(text)
         if not text:
+            self.keySequence = None
+            return
+        if 'Mouse ' in text:
             self.keySequence = None
             return
         try:
@@ -3891,7 +3895,8 @@ class ShortcutLineEdit(QLineEdit):
             super().mousePressEvent(event)
         else:
             # covers XButton1, XButton2, and any further extra buttons
-            self.setText(f'Mouse {button.name}')
+            btn_name = QtScoped.mouse_button_name(button)
+            self.setText(f'Mouse {btn_name}')
             
     def focusInEvent(self, event):
         super().focusInEvent(event)

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -76,7 +76,7 @@ from . import QtScoped
 from . import prompts
 from . import fonts
 from .acdc_regex import float_regex
-from .config import PREPROCESS_MAPPER
+from .config import PREPROCESS_MAPPER, STANDARD_MOUSE_BUTTONS
 from . import _base_widgets
 
 LINEEDIT_WARNING_STYLESHEET = _palettes.lineedit_warning_stylesheet()
@@ -3828,14 +3828,26 @@ def QKeyEventToString(event: QKeyEvent, notAllowedModifier=None):
     return keySequenceText
 
 class ShortcutLineEdit(QLineEdit):
+    clicked = Signal()
+    editingFinished = Signal()
     def __init__(
-            self, parent=None, allowModifiers=False, notAllowedModifier=None
+            self, parent=None, allowModifiers=False, notAllowedModifier=None,
+            allowMouseButtons=False
         ):
         self.keySequence = None
         super().__init__(parent)
         self._allowModifiers = allowModifiers
         self._notAllowedModifier = notAllowedModifier
         self.setAlignment(Qt.AlignCenter)
+        self._allowMouseButtons = allowMouseButtons
+        
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.MouseButtonPress:
+            button = event.button()
+            if button not in STANDARD_MOUSE_BUTTONS:
+                self.setText(f'Mouse {button.name}')
+                return True  # consume: don't let it reach the widget under the cursor
+        return super().eventFilter(obj, event)  # False for everything else -> passes through normally
     
     def text(self):
         text = macShortcutToWindows(super().text())
@@ -3871,7 +3883,24 @@ class ShortcutLineEdit(QLineEdit):
                 self.setText('')
             else:
                 self.setText(self.text().rstrip('+').strip())
+                
+    # catch mouse press events
+    def mousePressEvent(self, event):
+        button = event.button()
+
+        if button in STANDARD_MOUSE_BUTTONS or not self._allowMouseButtons:
+            super().mousePressEvent(event)
+        else:
+            # covers XButton1, XButton2, and any further extra buttons
+            self.setText(f'Mouse {button.name}')
             
+    def focusInEvent(self, event):
+        super().focusInEvent(event)
+        self.clicked.emit()  # or call your filter-install logic directly
+
+    def focusOutEvent(self, event):
+        self.editingFinished.emit()  # or call your filter-release logic directly
+        super().focusOutEvent(event)
 
 class selectStartStopFrames(QGroupBox):
     def __init__(self, SizeT, currentFrameNum=0, parent=None):

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -3901,6 +3901,12 @@ class ShortcutLineEdit(QLineEdit):
     def focusOutEvent(self, event):
         self.editingFinished.emit()  # or call your filter-release logic directly
         super().focusOutEvent(event)
+        
+    def sizeHint(self):
+        size_hint = super().sizeHint()
+        width = int(size_hint.width() * 1.5)
+        size_hint.setWidth(width)
+        return size_hint
 
 class selectStartStopFrames(QGroupBox):
     def __init__(self, SizeT, currentFrameNum=0, parent=None):


### PR DESCRIPTION
Adds new functionalities for shortcuts:
- Can now use mouse buttons as shortcuts
- Right-clicking buttons will open a menu so users can open shortcuts
- Implement new shortcuts, see #1142 
- Implement alphabetic sorting with a grouping option
- Implement exclusivity grouping checking
- Implemented hard-coded shortcut display and exclusivity checking for them
- Adds a projection toggle, which allows quick toggling between a single z slice and projections