### PR TITLE
Fixes for conversion of ImageJ ROIs to Cell-ACDC segmentation files

### DIFF
--- a/cellacdc/__main__.py
+++ b/cellacdc/__main__.py
@@ -30,7 +30,7 @@ if cellacdc_installation_path != site_packages:
             exit()
         print('*'*60)
         input(
-            '[WARNING]: Cell-ACDC had to clean-up and older installation. '
+            '[WARNING]: Cell-ACDC had to clean up an older installation. '
             'Please, re-start the software. Thank you for your patience! '
             '(Press any key to exit). '
         )

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -18098,12 +18098,18 @@ class ImageJRoisToSegmManager(QBaseDialog):
         mainLayout.addWidget(widgets.QHLine())
         mainLayout.addSpacing(5)
         
-        gridLayout = None
-        self.lowZspinbox = None
+        self.repeatRoiZstackGroupbox = None
         
         SizeT, SizeZ, SizeY, SizeX = TZYX_shape
         if SizeZ > 1:
-            gridLayout = QGridLayout()
+            self.repeatRoiZstackGroupbox = QGroupBox()
+            repeatRoiZstackLayout = QGridLayout()
+            self.repeatRoiZstackGroupbox.setCheckable(True)
+            self.repeatRoiZstackGroupbox.setTitle(
+                'ROI is 2D'
+            )
+            self.repeatRoiZstackGroupbox.setChecked(False)
+            self.repeatRoiZstackGroupbox.setLayout(repeatRoiZstackLayout)
             self.lowZspinbox = widgets.SpinBox()
             self.lowZspinbox.setMinimum(0)
             self.lowZspinbox.setMaximum(SizeZ-1)
@@ -18113,16 +18119,17 @@ class ImageJRoisToSegmManager(QBaseDialog):
             self.highZspinbox.setMaximum(SizeZ-1)
             self.highZspinbox.setValue(SizeZ-1)
             
-            gridLayout.addWidget(QLabel('Repeat 2D ROIs over z-range: '), 1, 0)
+            repeatRoiZstackLayout.addWidget(
+                QLabel('Repeat 2D ROIs over z-range: '), 1, 0)
             
-            gridLayout.addWidget(QLabel('Start z-slice'), 0, 1)
-            gridLayout.addWidget(self.lowZspinbox, 1, 1)
+            repeatRoiZstackLayout.addWidget(QLabel('Start z-slice'), 0, 1)
+            repeatRoiZstackLayout.addWidget(self.lowZspinbox, 1, 1)
             
-            gridLayout.addWidget(QLabel('Stop z-slice'), 0, 2)
-            gridLayout.addWidget(self.highZspinbox, 1, 2)
+            repeatRoiZstackLayout.addWidget(QLabel('Stop z-slice'), 0, 2)
+            repeatRoiZstackLayout.addWidget(self.highZspinbox, 1, 2)
         
-        if gridLayout is not None:
-            mainLayout.addLayout(gridLayout)
+        if self.repeatRoiZstackGroupbox is not None:
+            mainLayout.addWidget(self.repeatRoiZstackGroupbox)
             mainLayout.addSpacing(5)
             mainLayout.addWidget(widgets.QHLine())
             mainLayout.addSpacing(10)
@@ -18181,10 +18188,12 @@ class ImageJRoisToSegmManager(QBaseDialog):
         
         self.rescaleSizes = self.rescaleRoisGroupbox.inputOutputSizes()
         self.repeatRoisZslicesRange = None
-        if self.lowZspinbox is not None:
-            self.repeatRoisZslicesRange = (
-                self.lowZspinbox.value(), self.highZspinbox.value()+1
-            )
+        if self.repeatRoiZstackGroupbox is not None:
+            if self.repeatRoiZstackGroupbox.isChecked():
+                self.repeatRoisZslicesRange = (
+                    self.lowZspinbox.value(), 
+                    self.highZspinbox.value()+1
+                )
         
         self.cancel = False
         self.close()

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -2436,31 +2436,38 @@ def from_lab_to_imagej_rois(lab, ImagejRoi, t=0, SizeT=1, max_ID=None):
     return rois
 
 def from_imagej_rois_to_segm_data(
-        TZYX_shape, ID_to_roi_mapper, rescale_rois_sizes, 
-        repeat_2d_rois_zslices_range
+        TZYX_shape, 
+        ID_to_roi_mapper, 
+        rescale_rois_sizes, 
+        repeat_2d_rois_zslices_range: tuple[int, int] | None
     ):
     SizeT, SizeZ, SizeY, SizeX = TZYX_shape
     segm_data = np.zeros(TZYX_shape, dtype=np.uint32)
     for ID, roi in ID_to_roi_mapper.items():
         name = roi.name
-        name_parts = name.split('-')
+        is_3d_roi = (
+            roi.z_position > 0 or
+            roi.position > 0
+        )
         zz = [0]
-        if len(name_parts) == 2 and SizeZ > 1:
+        if repeat_2d_rois_zslices_range is not None and SizeZ > 1:
             # 2D roi in 3D segm data --> place 2D roi on each z-slice
             zz = range(*repeat_2d_rois_zslices_range)
-        
-        elif len(name_parts) > 2 and SizeZ > 1:
-            # 2D roi from a 3D roi --> place at requested z-slice
-            zz = [int(name_parts[-3])]
+        elif SizeZ > 1:
+            if roi.z_position > 0:
+                z = roi.z_position - 1
+            else:
+                # Fallback to position if z_position not encoded
+                z = roi.position - 1
+            zz = [z]
         
         tt = [0]*len(zz)
         if SizeT > 1:
-            tt = [roi.t_position]*len(zz)
+            tt = [roi.t_position - 1]*len(zz)
         
-        y0, x0 = roi.top, roi.left
-        contours = roi.integer_coordinates + (x0, y0)
-        xx = contours[:, 0]
-        yy = contours[:, 1]
+        coordinates = roi.coordinates()
+        xx = coordinates[:, 0]
+        yy = coordinates[:, 1]
         if rescale_rois_sizes is not None:        
             rescale_z = rescale_rois_sizes['Z']
             rescale_y = rescale_rois_sizes['Y']

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -3522,7 +3522,7 @@ class FromImajeJroiToSegmNpzWorker(BaseWorkerUtil):
                     rois = roifile.roiread(rois_filepath)
                     if not isinstance(rois, list):
                         rois = [rois]
-                    self.IDsToRoisMapper = {i+i: roi for roi in enumerate(rois)}
+                    self.IDsToRoisMapper = {i+i: roi for i, roi in enumerate(rois)}
                 else:
                     # Use same ID of previous position
                     rois = roifile.roiread(rois_filepath)
@@ -3538,8 +3538,7 @@ class FromImajeJroiToSegmNpzWorker(BaseWorkerUtil):
                 segm_data = myutils.from_imagej_rois_to_segm_data(
                     TZYX_shape, self.IDsToRoisMapper, self.rescaleRoisSizes, 
                     self.repeatRoisZslicesRange
-                )
-                
+                ) 
                 
                 segm_filepath = (rois_filepath
                     .replace('imagej_rois', 'segm')

--- a/cellacdc/workers.py
+++ b/cellacdc/workers.py
@@ -3477,6 +3477,7 @@ class FromImajeJroiToSegmNpzWorker(BaseWorkerUtil):
                 return
             
             self.askRoiPreferences = True
+            self.repeatRoisZslicesRange = None
             for p, pos in enumerate(pos_foldernames):
                 if self.abort:
                     self.signals.finished.emit(self)
@@ -3509,20 +3510,24 @@ class FromImajeJroiToSegmNpzWorker(BaseWorkerUtil):
                     is_multi_pos = len(pos_foldernames) > 1
                     self.logger.log('Loading image data to get image shape...')
                     TZYX_shape = load.get_tzyx_shape(images_path)
-                    abort = self.emitSelectRoisProps(
+                    cancel = self.emitSelectRoisProps(
                         rois_filepath, TZYX_shape, is_multi_pos
                     )
-                    if abort:
+                    if cancel:
                         self.signals.finished.emit(self)
                         return
                     
                     self.askRoiPreferences = not self.useSamePropsForNextPos
                 elif self.areAllRoisSelected:
                     rois = roifile.roiread(rois_filepath)
+                    if not isinstance(rois, list):
+                        rois = [rois]
                     self.IDsToRoisMapper = {i+i: roi for roi in enumerate(rois)}
                 else:
                     # Use same ID of previous position
                     rois = roifile.roiread(rois_filepath)
+                    if not isinstance(rois, list):
+                        rois = [rois]
                     IDsToRoisMapper = {i+i: roi for i, roi in enumerate(rois)}
                     self.IDsToRoisMapper = {
                         ID: IDsToRoisMapper[ID] 


### PR DESCRIPTION
This PR implements fixes for the `cellacdc.utils.fromImageJroiToSegm.py` utility. The utility now supports arbitrary types of ROIs though the use of the `roifile.ImagejRoi.coordinates()` method. 