### PR TITLE
Retrieve git branch with path, closes #1152

### DIFF
--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import ast
+import shlex
 
 import typing
 from typing import Literal, List, Callable, Tuple, Dict
@@ -55,6 +56,7 @@ from . import _warnings
 from . import urls
 from . import qrc_resources_path
 from . import settings_folderpath
+from . import cellacdc_installation_path
 
 from .models._cellpose_base import min_target_versions_cp
 
@@ -1061,7 +1063,9 @@ def get_date_from_version(version: str, package='cellacdc', debug=False):
     return 'ND'  
 
 def get_git_branch_name():
-    command = 'git rev-parse --abbrev-ref HEAD'
+    command = (
+        f'git -C "{cellacdc_installation_path}" rev-parse --abbrev-ref HEAD'
+    )
     output = _subprocess_run_command(
         command, shell=False, callback='check_output'
     )
@@ -3284,11 +3288,12 @@ def _subprocess_run_command(command, shell=True, callback='check_call'):
     try:
         out = func(command, shell=shell)
     except Exception as err:
+        commad_parts = shlex.split(command)
         print(
             f'[WARNING]: Command `{command}` failed. '
-            f'Trying with `{command.split()}`...'
+            f'Trying with `{commad_parts}`...'
         )
-        out = func(command.split(), shell=shell)
+        out = func(commad_parts, shell=shell)
     
     return out
 
@@ -3767,15 +3772,16 @@ def _install_pytorch_cli(
     
     if selected_command.startswith('conda'):
         try:
-            subprocess.check_call([selected_command], shell=True)
+            subprocess.check_call([commad_parts], shell=True)
         except Exception as err:
-            cmd_list = selected_command.split()
+            cmd_list = shlex.split(commad_parts)
             cmd_list = [cmd.strip('"') for cmd in cmd_list]
             cmd_list = [cmd.strip("'") for cmd in cmd_list]
             cmd_list = [cmd.lstrip(".") for cmd in cmd_list]
             subprocess.check_call(cmd_list, shell=True)
     else:
-        cmd_list = selected_command.split()[1:]
+        cmd_list = shlex.split(commad_parts)
+        cmd_list = cmd_list[1:]
         cmd_list = [cmd.strip('"') for cmd in cmd_list]
         cmd_list = [cmd.strip("'") for cmd in cmd_list]
         cmd_list = [cmd.lstrip(".") for cmd in cmd_list]
@@ -4071,7 +4077,7 @@ def run_fiji_command(command=None, logger_func=print):
         return False
 
     separator = '-'*100
-    commands = (command, command.split())
+    commands = (command, shlex.split(command))
     for args in commands:
         logger_func(
             f'{separator}\n'

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -3772,15 +3772,15 @@ def _install_pytorch_cli(
     
     if selected_command.startswith('conda'):
         try:
-            subprocess.check_call([commad_parts], shell=True)
+            subprocess.check_call([selected_command], shell=True)
         except Exception as err:
-            cmd_list = shlex.split(commad_parts)
+            cmd_list = shlex.split(selected_command)
             cmd_list = [cmd.strip('"') for cmd in cmd_list]
             cmd_list = [cmd.strip("'") for cmd in cmd_list]
             cmd_list = [cmd.lstrip(".") for cmd in cmd_list]
             subprocess.check_call(cmd_list, shell=True)
     else:
-        cmd_list = shlex.split(commad_parts)
+        cmd_list = shlex.split(selected_command)
         cmd_list = cmd_list[1:]
         cmd_list = [cmd.strip('"') for cmd in cmd_list]
         cmd_list = [cmd.strip("'") for cmd in cmd_list]

--- a/cellacdc/myutils.py
+++ b/cellacdc/myutils.py
@@ -3293,7 +3293,7 @@ def _subprocess_run_command(command, shell=True, callback='check_call'):
             f'[WARNING]: Command `{command}` failed. '
             f'Trying with `{commad_parts}`...'
         )
-        out = func(commad_parts, shell=shell)
+        out = func(commad_parts, shell=False)
     
     return out
 
@@ -3778,14 +3778,14 @@ def _install_pytorch_cli(
             cmd_list = [cmd.strip('"') for cmd in cmd_list]
             cmd_list = [cmd.strip("'") for cmd in cmd_list]
             cmd_list = [cmd.lstrip(".") for cmd in cmd_list]
-            subprocess.check_call(cmd_list, shell=True)
+            subprocess.check_call(cmd_list, shell=False)
     else:
         cmd_list = shlex.split(selected_command)
         cmd_list = cmd_list[1:]
         cmd_list = [cmd.strip('"') for cmd in cmd_list]
         cmd_list = [cmd.strip("'") for cmd in cmd_list]
         cmd_list = [cmd.lstrip(".") for cmd in cmd_list]
-        subprocess.check_call([sys.executable, *cmd_list], shell=True)
+        subprocess.check_call([sys.executable, *cmd_list], shell=False)
 
 def _get_pkg_command_pip_install(
         pkg_command, 

--- a/tests/test_retrieve_git_branch.py
+++ b/tests/test_retrieve_git_branch.py
@@ -1,0 +1,4 @@
+from cellacdc.myutils import get_git_branch_name
+
+def test_get_git_branch_name():
+    get_git_branch_name()


### PR DESCRIPTION
Currently, when initialising the logger, Cell-ACDC tries to retrieve the branch name to log this (see the `acdc -v` command. However, the branch retrieval failed when the `acdc` command was run from a folder that is not the cloned `Cell_ACDC` folder. This can be because the cloned folder does not exist, or because the user launches the command from any other folder.

To fix it, this PR implements the following 

- Specify the potential "git" folder using the `cellacdc.cellacdc_installation_path` with the flag `git -C "cellacdc_installation_path"` to retrieve the git branch name (if installation through cloning) in `cellacdc.myutils.get_git_branch_name`.
- Use of `shlex.split` to correctly split commands into list.