### PR TITLE
Fixes for issue #1157

### DIFF
--- a/cellacdc/cli.py
+++ b/cellacdc/cli.py
@@ -1771,6 +1771,7 @@ class ComputeMeasurementsKernel(_WorkflowKernel):
                 logger_func=self.logger.exception
             )
             if rp_errors:
+                rp_errors['frame_number'] = frame_i + 1
                 print('\n')
                 err_message = (
                     'WARNING: Some objects had the following errors:\n'

--- a/cellacdc/core.py
+++ b/cellacdc/core.py
@@ -3101,9 +3101,11 @@ def split_along_convexity_defects(
     if len(defects) != 2:
         return lab, success, []
 
+    # This line is needed since opencv-python-headless > 5.0
+    defects = np.asarray(defects).reshape(-1, 4)
     defects_points = [0]*len(defects)
     for i, defect in enumerate(defects):
-        s,e,f,d = defect[0]
+        s,e,f,d = defect
         x,y = tuple(cnt[f][0])
         defects_points[i] = (y,x)
     (r0, c0), (r1, c1) = defects_points

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -35083,21 +35083,21 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     
     def warnErrorsCustomMetrics(self):
         win = apps.ComputeMetricsErrorsDialog(
-            self.worker.customMetricsErrors, self.logs_path, 
+            self._saveDataWorker.customMetricsErrors, self.logs_path, 
             log_type='custom_metrics', parent=self
         )
         win.exec_()
     
     def warnErrorsAddMetrics(self):
         win = apps.ComputeMetricsErrorsDialog(
-            self.worker.addMetricsErrors, self.logs_path, 
+            self._saveDataWorker.addMetricsErrors, self.logs_path, 
             log_type='standard_metrics', parent=self
         )
         win.exec_()
     
     def warnErrorsRegionProps(self):
         win = apps.ComputeMetricsErrorsDialog(
-            self.worker.regionPropsErrors, self.logs_path, 
+            self._saveDataWorker.regionPropsErrors, self.logs_path, 
             log_type='region_props', parent=self
         )
         win.exec_()


### PR DESCRIPTION
This PR implements following fixes:

- Reshape the `defects` variable returned by `cellacdc.core.convexity_defects` for compatibility with any OpenCV version. This is needed because OpenCV v5 changed the returned shape.
- Better handling of `ZeroDivisionError('float division by zero')` when computing measurements

These issues have been reported in #1157 