### PR TITLE
Revert "Contours/segm masks and annotations during dragging frame slider, better capturing of "permanent" shortcuts through event filter"

### DIFF
--- a/cellacdc/annotate.py
+++ b/cellacdc/annotate.py
@@ -603,7 +603,6 @@ class TextAnnotations:
         isGenNumTreeAnnotation = self.isGenNumTreeAnnotation()
         rp_func = kwargs.get('rp_func')
         rp3D = kwargs.get('rp3D')
-        updateAllTextAnnotations = kwargs.get('updateAllTextAnnotations', True)
         
         acdc_df = posData.allData_li[posData.frame_i]['acdc_df']
         if posData.cca_df is not None and acdc_df is not None:
@@ -636,9 +635,6 @@ class TextAnnotations:
             pos = (int(xc), int(yc))
             
             isNewObject = obj.label in posData.new_IDs
-            if not isNewObject and not updateAllTextAnnotations:
-                continue
-            
             objOpts = get_obj_text_annot_opts(
                 obj, acdc_df, isCcaAnnot, isNewObject,
                 isAnnotateNumZslices, isLabelTreeAnnotation, 

--- a/cellacdc/debugutils.py
+++ b/cellacdc/debugutils.py
@@ -3,6 +3,8 @@ import atexit
 import linecache
 from collections import defaultdict
 
+from . import cellacdc_path, myutils
+
 import gc
 import psutil
 import time
@@ -112,7 +114,6 @@ def showRefGraph(object_str:str, debug:bool=True):
     try:
         import objgraph
     except ImportError:
-        from . import myutils
         conda_prefix, pip_prefix = myutils.get_pip_conda_prefix()
 
         print(f"objgraph is not installed. Install it with '{pip_prefix} objgraph' to use reference graph features, as well as https://www.graphviz.org/")
@@ -124,7 +125,6 @@ def showRefGraph(object_str:str, debug:bool=True):
     caller_line = inspect.currentframe().f_back.f_lineno
     timestap = datetime.datetime.now().strftime('%H_%M_%S')
 
-    from . import cellacdc_path
     ref_graph_path = os.path.join(
         os.path.dirname(cellacdc_path),
         '.ref_graphs'

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -54,7 +54,7 @@ from qtpy.QtWidgets import (
     QMainWindow, QMenu, QToolBar, QGroupBox, QGridLayout,
     QScrollBar, QCheckBox, QToolButton, QSpinBox, QButtonGroup, QActionGroup, QFileDialog, QAbstractSlider, QMessageBox, QWidget, QGridLayout, 
     QDockWidget, QGraphicsProxyWidget, QVBoxLayout, QRadioButton, 
-    QSpacerItem, QScrollArea, QFormLayout, QGraphicsSceneMouseEvent, QApplication
+    QSpacerItem, QScrollArea, QFormLayout, QGraphicsSceneMouseEvent 
 )
 
 import pyqtgraph as pg
@@ -236,8 +236,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         """Initializer."""
 
         super().__init__(parent)
-        
-        app.installEventFilter(self)
 
         self._version = version
 
@@ -5064,8 +5062,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.ax2_lostObjScatterItem = self.gui_getLostObjScatterItem()
         self.ax2_lostTrackedScatterItem = self.gui_getTrackedLostObjScatterItem()
         
-        self.gui_createTextAnnotItems(allIDs)
-        self.gui_setTextAnnotColors()
+        self.gui_createTextAnnotItems(allIDs) # here
+        self.gui_setTextAnnotColors()# here
 
         self.setDisabledAnnotOptions(False)
 
@@ -9340,10 +9338,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             specific_IDs=None, use_curr_view=False, use_bbox=False, preloaded_bbox=None, # for local updates to PR
             wl_update=True, wl_track_og_curr=False,wl_update_lab=False, # wl stuff
         ):
-        self.update_rp(draw=draw, debug=debug, # og stuff
-                       assignments=assignments, deletionIDs=deletionIDs, # very quick upates, rp labels are changed but rest is same
-                       specific_IDs=specific_IDs, use_curr_view=use_curr_view, use_bbox=use_bbox, preloaded_bbox=preloaded_bbox, # for local updates to PR
-                       wl_update=wl_update, wl_track_og_curr=wl_track_og_curr,wl_update_lab=wl_update_lab, # wl stuff
+        self.update_rp(draw=True, debug=False, # og stuff
+                       assignments=None, deletionIDs=None, # very quick upates, rp labels are changed but rest is same
+                       specific_IDs=None, use_curr_view=False, use_bbox=False, preloaded_bbox=None, # for local updates to PR
+                       wl_update=True, wl_track_og_curr=False,wl_update_lab=False, # wl stuff
                        )
         waitcond.wakeAll()
 
@@ -16334,30 +16332,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     
     def editingSpinboxValueTimerCallback(self):
         self.typingEditID = False
-        
-    def eventFilter(self, obj, ev):
-        if not getattr(self, 'isDataLoaded', False):
-            return False
-
-        focus = QApplication.focusWidget()
-        if focus is not None and any(
-            focus.inherits(cls) for cls in (
-                'QLineEdit', 'QTextEdit', 'QPlainTextEdit', 'QAbstractSpinBox'
-            )
-        ):
-            return False
-        if ev.type() == QEvent.Type.KeyPress:
-            for name, key in self.widgetsPersistentShortcut.items():
-                if not key == ev.key():
-                    continue
-                action = self.widgetsWithShortcut[name]
-                if hasattr(action, 'click'):
-                    action.click()
-                elif hasattr(action, 'trigger'):
-                    action.trigger()
-                return True
-        return False
-        
+    
     @exception_handler
     def keyPressEvent(self, ev):        
         ctrl = ev.modifiers() == Qt.ControlModifier
@@ -16396,6 +16371,17 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         if ev.key() == Qt.Key_End:
             self.onKeyEnd()
+            
+        for name, key in self.widgetsPersistentShortcut.items():
+            if not key == ev.key():
+                continue
+            action = self.widgetsWithShortcut[name]
+            success = False
+            if hasattr(action, 'click'):
+                action.click()
+            elif hasattr(action, 'trigger'):
+                action.trigger()
+            break
         
         modifiers = ev.modifiers()
         isAltModifier = modifiers == Qt.AltModifier
@@ -21679,14 +21665,35 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         if singleMove:
             self.update_z_slice(self.zSliceScrollBar.sliderPosition())
         elif action == SliderMove:
+            if self.zSliceScrollBarStartedMoving and self.isSegm3D:
+                self.clearAx1Items(onlyHideText=True)
+                self.clearAx2Items(onlyHideText=True)
             posData = self.data[self.pos_i]
             idx = (posData.filename, posData.frame_i)
             z = self.zSliceScrollBar.sliderPosition()
             if self.switchPlaneCombobox.depthAxes() == 'z': 
                 posData.segmInfo_df.at[idx, 'z_slice_used_gui'] = z
             self.zSliceSpinbox.setValueNoEmit(z+1)
+            img = self._getImageupdateAllImages(None)
+            self.img1.setCurrentZsliceIndex(z)
+            self.img1.setImage(
+                img, next_frame_image=self.nextFrameImage(),
+                scrollbar_value=posData.frame_i+2
+            )
+            try:
+                self.setOverlayImages()
+            except Exception as err:
+                pass
+            
+            if self.labelsGrad.showLabelsImgAction.isChecked():
+                self.img2.setImage(posData.lab, z=z, autoLevels=False)
+            self.updateViewerWindow()
+            self.setTextAnnotZsliceScrolling()
+            self.setGraphicalAnnotZsliceScrolling()
+            self.setOverlayLabelsItems()
+            self.drawPointsLayers(computePointsLayers=False)
             self.zSliceScrollBarStartedMoving = False
-            self.updateAllImages()
+            self.highlightSearchedID(self.highlightedID, force=True)
             
     def maxProjToggleActionTriggered(self):
         posData = self.data[self.pos_i]
@@ -22321,13 +22328,21 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             posData.allData_li[posData.frame_i]['regionprops'] = rp
         else:
             posData.lab = posData.allData_li[posData.frame_i]['labels']
-            posData.rp = posData.allData_li[posData.frame_i]['regionprops']
 
-        posData.IDs = posData.rp.IDs
-        self.updateLostNewCurrentIDs()
-        self.updateAllImages()
+        self.setImageImg1()
+        if self.overlayButton.isChecked():
+            self.setOverlayImages()
+
+        if self.navigateScrollBarStartedMoving:
+            self.clearAllItems()
+
+        self.navSpinBox.setValueNoEmit(posData.frame_i+1)
+        if self.labelsGrad.showLabelsImgAction.isChecked():
+            self.img2.setImage(posData.lab, z=self.z_lab(), autoLevels=False)
+        self.updateLookuptable()
         self.updateFramePosLabel()
         self.updateViewerWindow()
+        self.updateTimestampFrame()
         self.updateHighlightedAxis()
         self.navigateScrollBarStartedMoving = False
 
@@ -22392,10 +22407,10 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         
         # make rp remporarliy not stale anymore
         rp.update_regionprops_via_assignments(assignments, lab) 
-        assignments_new = self.trackFrame(
+        tracked_lab, assignments_new = self.trackFrame(
             nextLab, nextRp, lab, rp, rp.IDs,
             assign_unique_new_IDs=False, return_assignments=True,
-            specific_IDs=[newID], dont_return_tracked_lab=True
+            specific_IDs=[newID], 
         )
         # restore rp
         posData.rp.update_regionprops_via_assignments(reverse_assignments, lab)
@@ -30028,11 +30043,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         return rp_2D
 
     # @exec_time
-    def setAllTextAnnotations(
-            self, 
-            labelsToSkip=None, 
-            updateAllTextAnnotations=True
-        ):
+    def setAllTextAnnotations(self, labelsToSkip=None):
         self.setLostNewOldPrevIDs()
         posData = self.data[self.pos_i]
         
@@ -30045,8 +30056,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             getCurrentZfunc=self.z_lab, 
             getObjCentroidFunc=self.getObjCentroid,
             rp_func=self.get2DRP,
-            rp3D=posData.rp,
-            updateAllTextAnnotations=updateAllTextAnnotations
+            rp3D=posData.rp
         )
         self.textAnnot[1].setAnnotations(
             posData=posData, labelsToSkip=labelsToSkip, 
@@ -30055,8 +30065,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             annotateLost=self.annotLostObjsToggle.isChecked(), 
             getObjCentroidFunc=self.getObjCentroid,
             rp_func=self.get2DRP,
-            rp3D=posData.rp,
-            updateAllTextAnnotations=updateAllTextAnnotations
+            rp3D=posData.rp
         )
         self.textAnnot[0].update()
         self.textAnnot[1].update()
@@ -30191,7 +30200,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     @exception_handler
     def updateAllImages(
             self, image=None, computePointsLayers=True, computeContours=True,
-            updateLookuptable=True, updateAllTextAnnotations=True
+            updateLookuptable=True
         ):
         self.clearAllItems()
 
@@ -30217,9 +30226,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         # self.update_rp()
 
         # Annotate ID and draw contours
-        self.setAllTextAnnotations(
-            updateAllTextAnnotations=updateAllTextAnnotations
-        )    
+        self.setAllTextAnnotations()    
         self.setAllContoursImages(
             compute=False
         )
@@ -30944,6 +30951,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 trackedID, assignments = self.trackNewIDtoNewIDsFutureFrame(added_ID, obj, assignments)
                 if trackedID is None:
                     self.clearAssignedObjsSecondStep()
+                    # update assignments
+                    
                     continue
                 posData.lab[obj.slice][obj.image] = trackedID
         
@@ -30982,26 +30991,6 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         ):
         from .trackers.CellACDC import CellACDC_tracker
         
-        handle_specific_IDs_self  = False
-        return_assignments_og = return_assignments
-        dont_return_tracked_lab_og = dont_return_tracked_lab
-        does_it_have_specific_IDs_kwarg = (
-            specific_IDs is not None
-            and (
-                self.trackWithYeazAction.isChecked()
-                or (
-                    self.realTimeTracker_kwargs is not None 
-                    and 'specific_IDs' not in self.realTimeTracker_kwargs
-                )
-            )
-        )
-        if does_it_have_specific_IDs_kwarg:
-            # Yeaz tracker or custom tracker without specific_IDs functionality
-            return_assignments = True
-            dont_return_tracked_lab = True
-            handle_specific_IDs_self = True
-            curr_lab_backup = curr_lab.copy()
-        
         if self.trackWithAcdcAction.isChecked():
             tracked_result = CellACDC_tracker.track_frame(
                 prev_lab, prev_rp, curr_lab, curr_rp,
@@ -31021,10 +31010,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             )
         else:
             tracked_result = self.trackFrameCustomTracker(
-                prev_lab, curr_lab, prev_rp, curr_rp, 
-                specific_IDs=specific_IDs, unique_ID=unique_ID,
-                dont_return_tracked_lab=dont_return_tracked_lab, 
-                return_assignments=return_assignments
+                prev_lab, curr_lab, prev_rp, curr_rp, specific_IDs=specific_IDs, unique_ID=unique_ID,
+                dont_return_tracked_lab=dont_return_tracked_lab, return_assignments=return_assignments
             )
 
         # Check if tracker also returns additional info
@@ -31043,11 +31030,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         else:
             tracked_lab = tracked_result
         
-        if (
-            not return_assignments_og 
-            and not dont_return_tracked_lab_og 
-            and not handle_specific_IDs_self
-            ):
+        if not return_assignments and not dont_return_tracked_lab:
             return tracked_lab
 
         # get assignments
@@ -31060,34 +31043,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                     assignments[old_lab] = new_lab
                 except:
                     import pdb; pdb.set_trace()
-                    
-        if handle_specific_IDs_self:
-            # Filter assignments to only include specific_IDs
-            assignments = {old_ID: new_ID 
-                           for old_ID, new_ID in assignments.items()
-                           if old_ID in specific_IDs
-                           and new_ID not in curr_rp.IDs_set # avoid merging
-                           }
-                    
-        
-        if dont_return_tracked_lab_og:
+
+        if dont_return_tracked_lab:
             return assignments
-        
-        if handle_specific_IDs_self:
-            # apply assignments to tracked_lab
-            for old_ID, new_ID in assignments.items():
-                if old_ID not in specific_IDs:
-                    continue
-
-                if old_ID == new_ID:
-                    continue # nothing to do
-                obj_curr = curr_rp.get_obj_from_ID(old_ID)
-                curr_lab_backup[obj_curr.slice][obj_curr.image] = new_ID
-            tracked_lab = curr_lab_backup
-                    
-        if not return_assignments_og and not dont_return_tracked_lab_og:
-            return tracked_lab
-
         return tracked_lab, assignments
     
     def clearAssignedObjsSecondStep(self):
@@ -31238,8 +31196,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         QTimer.singleShot(50, partial(
             self.statusBarLabel.setText, staturBarLabelText
         ))
-        if return_assignments:
+        if return_assignments and return_lab:
+            return tracked_lab, assignments
+        elif return_assignments:
             return assignments
+        elif return_lab:
+            return tracked_lab
 
     def handleAdditionalInfoRealTimeTracker(self, prev_rp, add_info):
         assignments = None

--- a/cellacdc/trackers/CellACDC/CellACDC_tracker.py
+++ b/cellacdc/trackers/CellACDC/CellACDC_tracker.py
@@ -104,7 +104,7 @@ def calc_Io_matrix(
     if _HAS_CYTHON_IOA:
         use_union = denom == 'union'
         curr_IDs_arr  = np.array(IDs_curr_untracked, dtype=np.uint32)
-        prev_IDs_arr  = np.array(IDs_prev, dtype=np.uint32)
+        prev_IDs_arr  = np.array(IDs_prev,           dtype=np.uint32)
         prev_areas_arr = np.array(
             [obj.area for obj in prev_rp], 
             dtype=np.uint32
@@ -170,10 +170,6 @@ def assign(
     counts_dict = dict(zip(unique_col_idx, counts))
     tracked_IDs = []
     old_IDs = []
-    if specific_IDs is not None:
-        static_IDs = set(
-            [ID for ID in IDs_curr_untracked if ID not in specific_IDs])
-
 
     if DEBUG:
         printl(f'IDs in previous frame: {IDs_prev}')
@@ -197,10 +193,6 @@ def assign(
                 continue
 
         tracked_ID = IDs_prev[j]
-        
-        if specific_IDs is not None:
-            if tracked_ID in static_IDs: # make sure we dont merge with static IDs
-                continue
         old_ID = IDs_curr_untracked[i]
         tracked_IDs.append(tracked_ID)
         old_IDs.append(old_ID)

--- a/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
+++ b/cellacdc/trackers/CellACDC_normal_division/CellACDC_normal_division_tracker.py
@@ -211,7 +211,10 @@ class normal_division_tracker:
     cells.
     - segm_video (ndarray): The segmented video sequence.
     - tracked_video (ndarray): The tracked video sequence.
-    - assignments (dict): Dictionary mapping IDs to assigned values.
+    - assignments (dict): A dictionary mapping untracked cell IDs to tracked 
+    cell IDs. (Only NEW cells are in this dictionary, so things the tracker 
+    could not assign to a cell in the previous frame and was given a new unique 
+    ID.)
     - IDs_prev (list): A list mapping index from IoA matrix to IDs. (Index in 
     list = Index in IoA matrix)
     - rp (list): The region properties of the current frame.
@@ -275,7 +278,7 @@ class normal_division_tracker:
 
     def track_frame(self, frame_i, lab=None, prev_lab=None, rp=None, prev_rp=None,
                     IDs=None, unique_ID=None, 
-                    return_assignments=False, 
+                    return_assignments=False, specific_IDs=None, 
                     dont_return_tracked_lab=False, lost_IDs_search_range=None,
                     ):
         """
@@ -316,14 +319,21 @@ class normal_division_tracker:
         if prev_rp is None:
             prev_rp = acdcRegionprops(prev_lab.copy(), precache_centroids=False)
 
-        IoA_matrix, self.IDs_curr_untracked, self.IDs_prev = calc_Io_matrix(
+        full_IoA_matrix, full_curr_IDs, self.IDs_prev = calc_Io_matrix(
             lab,
             prev_lab,
             self.rp,
             prev_rp,
         )
+        IoA_matrix, self.IDs_curr_untracked, _ = calc_Io_matrix(
+            lab,
+            prev_lab,
+            self.rp,
+            prev_rp,
+            specific_IDs=specific_IDs,
+        )
         full_aggr_track, full_mother_daughters = mother_daughter_assign(
-            IoA_matrix,
+            full_IoA_matrix,
             IoA_thresh_daughter=self.IoA_thresh_daughter,
             min_daughter=self.min_daughter,
             max_daughter=self.max_daughter,
@@ -334,16 +344,16 @@ class normal_division_tracker:
             curr_ID: idx for idx, curr_ID in enumerate(self.IDs_curr_untracked)
         }
         self.aggr_track = [
-            subset_idx_mapper[self.IDs_curr_untracked[idx]]
+            subset_idx_mapper[full_curr_IDs[idx]]
             for idx in full_aggr_track
-            if self.IDs_curr_untracked[idx] in subset_idx_mapper
+            if full_curr_IDs[idx] in subset_idx_mapper
         ]
         self.mother_daughters = []
         for mother_idx, daughter_idxs in full_mother_daughters:
             subset_daughter_idxs = [
-                subset_idx_mapper[self.IDs_curr_untracked[idx]]
+                subset_idx_mapper[full_curr_IDs[idx]]
                 for idx in daughter_idxs
-                if self.IDs_curr_untracked[idx] in subset_idx_mapper
+                if full_curr_IDs[idx] in subset_idx_mapper
             ]
             if subset_daughter_idxs:
                 self.mother_daughters.append((mother_idx, subset_daughter_idxs))
@@ -365,8 +375,9 @@ class normal_division_tracker:
             return_all=True,
             mother_daughters=self.mother_daughters,
             unique_ID=unique_ID,
+            specific_IDs=specific_IDs,
             return_assignments=return_assignments,
-            dont_return_tracked_lab=_dont_return_tracked_lab, 
+            dont_return_tracked_lab=_dont_return_tracked_lab,
         )
         if _dont_return_tracked_lab:
             add_info = out
@@ -377,90 +388,47 @@ class normal_division_tracker:
         IoA_matrix = add_info['IoA_matrix']
         self.assignments = add_info['assignments']
         self.tracked_IDs = add_info['tracked_IDs']
-        assignments_step_1 = self.assignments.copy()
-        
-        # print("After step 1")
-        # print("IDs_prev:", self.IDs_prev)
-        # print("IDs_curr_untracked:", self.IDs_curr_untracked)
-        # print("mother_daughters:", self.mother_daughters)
-        # print("assignments before merge:", add_info["assignments"])
-        # print("assignments after merge:", self.assignments)
-
-        # for mother, daughters in self.mother_daughters:
-            # print(
-            #     "mother",
-            #     mother,
-            #     "mother ID",
-            #     self.IDs_prev[mother],
-            #     "daughter idx",
-            #     daughters,
-            #     "daughter seg IDs",
-            #     [self.IDs_curr_untracked[d] for d in daughters],
-            #     "daughter tracked IDs",
-            #     IoA_index_daughter_to_ID(
-            #         daughters,
-            #         self.assignments,
-            #         self.IDs_curr_untracked,
-            #     ),
-            #     )            
+            
         if lost_IDs_search_range is None:
             return
         
         updated_rp = acdcRegionprops(self.tracked_lab, precache_centroids=False)
       
         mothers = {self.IDs_prev[mother] for mother, _ in self.mother_daughters}
-        # daughters_curr = set()
-        daughters_tracked = set()
+        daughters = set()
         for _, daughter_idxs in self.mother_daughters:
-            daughter_IDs_tracked = IoA_index_daughter_to_ID(
+            daughter_IDs = IoA_index_daughter_to_ID(
                 daughter_idxs, self.assignments, self.IDs_curr_untracked
             )
-            if daughter_IDs_tracked:
-                daughters_tracked.update(daughter_IDs_tracked)
+            if daughter_IDs:
+                daughters.update(daughter_IDs)
             
-            # daughter_IDs_curr = IoA_index_daughter_to_ID(
-            #     daughter_idxs, None, self.IDs_curr_untracked
-            # )
-            # if daughter_IDs_curr:
-            #     daughters_curr.update(daughter_IDs_curr)
-                
         selected_tracked_IDs = None
-        # if specific_IDs is not None:
-        #     selected_tracked_IDs = {
-        #         self.assignments.get(curr_ID, curr_ID)
-        #         for curr_ID in specific_IDs
-        #     }
+        if specific_IDs is not None:
+            selected_tracked_IDs = {
+                self.assignments.get(curr_ID, curr_ID)
+                for curr_ID in specific_IDs
+            }
+        
+        prev_rp_mapper = {obj.label: obj for obj in prev_rp 
+                          if obj.label not in mothers}
 
-        # print("selected_tracked_IDs:", selected_tracked_IDs)
-        curr_IDs = updated_rp.IDs_set
         lost_rp_mapper = {
             obj.label: obj for obj in prev_rp
-            if obj.label not in curr_IDs # not in current frame, i.e. not tracked/lost
-            and obj.label not in mothers # not a mother cell
+            if obj.label not in self.tracked_IDs and obj.label not in daughters
         }
-        # print("curr_IDs:", curr_IDs)
-        # print("mothers:", mothers)
-        # print("prev_rp:", prev_rp.IDs_set)
-        # print("lost_rp_mapper:", lost_rp_mapper)
+
         if not lost_rp_mapper:
             return
 
-        IDs_prev = prev_rp.IDs_set
         new_rp_mapper = {
             obj.label: obj for obj in updated_rp
             if (
                 selected_tracked_IDs is None
-                or obj.label in selected_tracked_IDs # only consider selected IDs if provided
+                or obj.label in selected_tracked_IDs
             )
-            and obj.label not in daughters_tracked # not already tracked as a daughter
-            and obj.label not in IDs_prev # not in previous frame, i.e. not tracked/new
+            if prev_rp_mapper.get(obj.label) is None
         }
-        
-        # print("updated_rp:", updated_rp.IDs_set)
-        # print("selected_tracked_IDs:", selected_tracked_IDs)
-        # print("daughters_tracked:", daughters_tracked)
-        # print("IDs_prev:", IDs_prev)
-        # print("new_rp_mapper:", new_rp_mapper.keys())
 
         if not new_rp_mapper:
             return
@@ -506,7 +474,6 @@ class normal_division_tracker:
                 tracked_objs_2nd_step.append(lost_IDs_idx_to_obj_mapper[i])
 
         if not IDs_to_track:
-            # print("No IDs to track")
             return
 
         # Only touch self.tracked_lab / write to the video array when it
@@ -526,19 +493,16 @@ class normal_division_tracker:
             )
 
         assignments_step_2 = dict(zip(IDs_to_track, tracked_IDs_2nd_step))
-        current_frame_IDs = self.rp.IDs_set
-        # if specific_IDs is not None:
-        #     current_frame_IDs.intersection_update(specific_IDs)
+        current_frame_IDs = {obj.label for obj in self.rp}
+        if specific_IDs is not None:
+            current_frame_IDs.intersection_update(specific_IDs)
 
         merged_assignments = {}
         for current_ID in current_frame_IDs:
-            tracked_ID = assignments_step_1.get(current_ID, current_ID)
-            tracked_ID = assignments_step_1.get(current_ID, current_ID)
+            tracked_ID = self.assignments.get(current_ID, current_ID)
 
             visited = set()
-            while (tracked_ID in assignments_step_2 
-                   and tracked_ID not in visited
-                   ):
+            while tracked_ID in assignments_step_2 and tracked_ID not in visited:
                 visited.add(tracked_ID)
                 tracked_ID = assignments_step_2[tracked_ID]
 
@@ -546,31 +510,7 @@ class normal_division_tracker:
                 merged_assignments[current_ID] = tracked_ID
 
         self.assignments = merged_assignments
-        self.tracked_IDs = list(merged_assignments.keys())
-        # print("After step 2")
-        # print("IDs_prev:", self.IDs_prev)
-        # print("IDs_curr_untracked:", self.IDs_curr_untracked)
-        # print("mother_daughters:", self.mother_daughters)
-        # print("assignments before merge:", assignments_step_2)
-        # print("assignments after merge:", merged_assignments)
-
-        # for mother, daughters in self.mother_daughters:
-        #     print(
-        #         "mother",
-        #         mother,
-        #         "mother ID",
-        #         self.IDs_prev[mother],
-        #         "daughter idx",
-        #         daughters,
-        #         "daughter seg IDs",
-        #         [self.IDs_curr_untracked[d] for d in daughters],
-        #         "daughter tracked IDs",
-        #         IoA_index_daughter_to_ID(
-        #             daughters,
-        #             self.assignments,
-        #             self.IDs_curr_untracked,
-        #         ),
-        #         )       
+        self.tracked_IDs = list(current_frame_IDs)
 
         return
         
@@ -1388,7 +1328,7 @@ class tracker:
               max_daughter:int = 2,
               record_lineage:bool = True,
               return_tracked_lost_centroids:bool = True,
-              lost_IDs_search_range:float = 10,
+              lost_IDs_search_range:float = 0,
               signals = None,
         ):
         """
@@ -1413,8 +1353,7 @@ class tracker:
         Defaults to True.
         - lost_IDs_search_range (float, optional): Maximum distance a cell 
         can move between consecutive frames to still be matched to a lost ID in 
-        the 2nd tracking step. If 0, the 2nd step is skipped entirely. 
-        Defaults to 10.
+        the 2nd tracking step. If 0, the 2nd step is skipped entirely. Defaults to 0.
         
         Returns:
         - list: Tracked video frames.
@@ -1527,7 +1466,7 @@ class tracker:
                     lost_IDs_search_range: float = 0,
                     unique_ID: NotGUIParam =None,
                     return_assignments: NotGUIParam =False,
-                    # specific_IDs: NotGUIParam =None,
+                    specific_IDs: NotGUIParam =None,
                     dont_return_tracked_lab: NotGUIParam =False,
                     prev_rp: NotGUIParam=None,
                     curr_rp: NotGUIParam=None,
@@ -1579,7 +1518,7 @@ class tracker:
             IDs=IDs,
             unique_ID=unique_ID,
             return_assignments=return_assignments,
-            # specific_IDs=specific_IDs,
+            specific_IDs=specific_IDs,
             dont_return_tracked_lab=dont_return_tracked_lab,
             lost_IDs_search_range=lost_IDs_search_range,
             prev_rp=prev_rp,

--- a/tests/test_cellacdc_tracker_specific_ids.py
+++ b/tests/test_cellacdc_tracker_specific_ids.py
@@ -118,43 +118,43 @@ def test_two_steps_specific_ids_can_match_selected_new_object_to_lost_previous_i
     assert add_info['assignments'] == {7: 5}
 
 
-# def test_normal_division_specific_ids_preserve_division_context():
-#     prev_lab = np.array(
-#         [
-#             [5, 5, 5, 5],
-#             [5, 5, 5, 5],
-#         ],
-#         dtype=np.uint16,
-#     )
-#     lab = np.array(
-#         [
-#             [7, 7, 8, 8],
-#             [7, 7, 8, 8],
-#         ],
-#         dtype=np.uint16,
-#     )
+def test_normal_division_specific_ids_preserve_division_context():
+    prev_lab = np.array(
+        [
+            [5, 5, 5, 5],
+            [5, 5, 5, 5],
+        ],
+        dtype=np.uint16,
+    )
+    lab = np.array(
+        [
+            [7, 7, 8, 8],
+            [7, 7, 8, 8],
+        ],
+        dtype=np.uint16,
+    )
 
-#     tracked_lab, add_info = NormalDivisionTracker().track_frame(
-#         prev_lab,
-#         lab,
-#         IoA_thresh=0.8,
-#         IoA_thresh_daughter=0.25,
-#         IoA_thresh_aggressive=0.5,
-#         min_daughter=2,
-#         max_daughter=2,
-#         unique_ID=20,
-#         return_assignments=True,
-#         specific_IDs=[7],
-#     )
+    tracked_lab, add_info = NormalDivisionTracker().track_frame(
+        prev_lab,
+        lab,
+        IoA_thresh=0.8,
+        IoA_thresh_daughter=0.25,
+        IoA_thresh_aggressive=0.5,
+        min_daughter=2,
+        max_daughter=2,
+        unique_ID=20,
+        return_assignments=True,
+        specific_IDs=[7],
+    )
 
-#     expected = np.array(
-#         [
-#             [20, 20, 8, 8],
-#             [20, 20, 8, 8],
-#         ],
-#         dtype=np.uint16,
-#     )
+    expected = np.array(
+        [
+            [20, 20, 8, 8],
+            [20, 20, 8, 8],
+        ],
+        dtype=np.uint16,
+    )
 
-#     np.testing.assert_array_equal(tracked_lab, expected)
-#     assert add_info['mothers'] == {5}
-#     assert add_info['assignments'] == {7: 20}
+    np.testing.assert_array_equal(tracked_lab, expected)
+    assert add_info['mothers'] == {5}
+    assert add_info['assignments'] == {7: 20}


### PR DESCRIPTION
Reverts SchmollerLab/Cell_ACDC#1153

The new logic of `framesScrollBarMoved` messes up cell cycle annotations (and who knows what else). 

This PR reverts those changes since they are anyway in PR #1160. 

The functionality of dragging the slider will be tested in PR #1160 