### PR TITLE
Crf setting video export, closes #1162

### DIFF
--- a/cellacdc/annotate.py
+++ b/cellacdc/annotate.py
@@ -415,7 +415,7 @@ class TextAnnotationsScatterItem(pg.GraphicsObject):
             return
 
         device_rect = painter.worldTransform().mapRect(source_rect)
-        width, height = abs(device_rect.width()), abs(device_rect.height())
+        width, height = int(abs(device_rect.width())), int(abs(device_rect.height()))
         
         # self._boundedCacheSize(
         #     abs(device_rect.width()), abs(device_rect.height())

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -16510,10 +16510,12 @@ class ExportToVideoParametersDialog(QBaseDialog):
                                                 minimum=0, maximum=51)
             gridLayout.addWidget(self.crf_widget, row, 1)
             info_txt = """
-            The range of the CRF scale is 0-51, where 0 is lossless (for 8 bit 
-            only, for 10 bit use -qp 0), 23 is the default, and 51 is worst 
-            quality possible. A lower value generally leads to higher quality, 
-            and a subjectively sane range is 17-28. Consider 17 or 18 to be 
+            The range of the Constant Rate Factor (CRF) scale is 0-51, where 0 is lossless, 23 is the default, and 51 is worst quality possible.
+            <br><br> 
+            A <b>lower value</b> generally leads to a <b>higher quality</b>, 
+            and a subjectively sane range is 17-28.
+            <br><br>
+            Consider 17 or 18 to be 
             visually lossless or nearly so; it should look the same or nearly 
             the same as the input but it isn't technically lossless.
             <br><br>
@@ -16522,8 +16524,7 @@ class ExportToVideoParametersDialog(QBaseDialog):
             to roughly twice the bitrate.
             <br><br>
             Choose the highest CRF value that still provides an acceptable 
-            quality. If the output looks good, then try a higher value. If it 
-            looks bad, choose a lower value.
+            quality. If the output looks good, but the video file size is too big for you, try a higher value. If it looks bad, choose a lower value.
             <br><br>
             For more information, see 
             <a href="https://trac.ffmpeg.org/wiki/Encode/H.264#crf">
@@ -16531,7 +16532,7 @@ class ExportToVideoParametersDialog(QBaseDialog):
             """
             infobutton = widgets.infoPushButton(
                 info_text=info_txt, 
-                info_title='CRF information'
+                info_title='Constant Rate Factor (CRF) information'
                 )
             gridLayout.addWidget(infobutton, row, 2)
         else:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -16503,6 +16503,40 @@ class ExportToVideoParametersDialog(QBaseDialog):
             self.saveFramesToggle, row, 1, alignment=Qt.AlignCenter
         )
         
+        if isTimelapseVideo:
+            row += 1
+            gridLayout.addWidget(QLabel('Video compression quality preset (crf)'), row, 0)
+            self.crf_widget = widgets.IntLineEdit(allowNegative=False, initial=23, 
+                                                minimum=0, maximum=51)
+            gridLayout.addWidget(self.crf_widget, row, 1)
+            info_txt = """
+            The range of the CRF scale is 0-51, where 0 is lossless (for 8 bit 
+            only, for 10 bit use -qp 0), 23 is the default, and 51 is worst 
+            quality possible. A lower value generally leads to higher quality, 
+            and a subjectively sane range is 17-28. Consider 17 or 18 to be 
+            visually lossless or nearly so; it should look the same or nearly 
+            the same as the input but it isn't technically lossless.
+            <br><br>
+            The range is exponential, so increasing the CRF value 
+            +6 results in roughly half the bitrate / file size, while -6 leads 
+            to roughly twice the bitrate.
+            <br><br>
+            Choose the highest CRF value that still provides an acceptable 
+            quality. If the output looks good, then try a higher value. If it 
+            looks bad, choose a lower value.
+            <br><br>
+            For more information, see 
+            <a href="https://trac.ffmpeg.org/wiki/Encode/H.264#crf">
+            this page</a>.
+            """
+            infobutton = widgets.infoPushButton(
+                info_text=info_txt, 
+                info_title='CRF information'
+                )
+            gridLayout.addWidget(infobutton, row, 2)
+        else:
+            self.crf_widget = None
+        
         gridLayout.setColumnStretch(0, 0)
         gridLayout.setColumnStretch(1, 1)
         gridLayout.setColumnStretch(2, 0)
@@ -16603,6 +16637,7 @@ class ExportToVideoParametersDialog(QBaseDialog):
             'save_pngs':  self.saveFramesToggle.isChecked(),
             'is_timelapse': self.isTimelapseVideo,
             'dpi': self.dpiWidget.value(),
+            'crf': self.crf_widget.value() if self.crf_widget is not None else None
         }
         return preferences
     

--- a/cellacdc/exporters.py
+++ b/cellacdc/exporters.py
@@ -159,34 +159,34 @@ class VideoExporter:
     def release(self):
         self.writer.release()
     
-    def avi_to_mp4(self):
-        avi_to_mp4(self._avi_filepath)
+    def avi_to_mp4(self, crf=18):
+        avi_to_mp4(self._avi_filepath, crf=crf)
 
-def avi_to_mp4(in_filepath_avi, out_filepath_mp4=None):
-    ffmep_exec_path = myutils.download_ffmpeg()
+def avi_to_mp4(in_filepath_avi, out_filepath_mp4=None, crf=18):
+    ffmpeg_exec_path = myutils.download_ffmpeg()
     
     if out_filepath_mp4 is None:
         out_filepath_mp4 = in_filepath_avi.replace('.avi', '.mp4')
     
-    ffmep_exec_path = ffmep_exec_path.replace('\\', '/')
+    ffmpeg_exec_path = ffmpeg_exec_path.replace('\\', '/')
     out_filepath_mp4 = out_filepath_mp4.replace('\\', '/')
     in_filepath_avi = in_filepath_avi.replace('\\', '/')
     
     args = [
         '-i', f'{in_filepath_avi}', '-c:v', 'libx264', 
-        '-crf', '18', '-an', f'{out_filepath_mp4}'
+        '-crf', str(crf), '-an', f'{out_filepath_mp4}'
     ]
     
-    _run_ffmpeg(ffmep_exec_path, args)
+    _run_ffmpeg(ffmpeg_exec_path, args)
 
-def _run_ffmpeg(ffmep_exec_path, command_args):
+def _run_ffmpeg(ffmpeg_exec_path, command_args):
     import subprocess, os
     
     command_args_no_quotes = [
         arg.replace('"', '').replace("'", '') for arg in command_args
     ]
     full_command = ' '.join(command_args_no_quotes)
-    full_command = f'{ffmep_exec_path} {full_command}'
+    full_command = f'{ffmpeg_exec_path} {full_command}'
     
     separator = '-'*100
     print(

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -34426,7 +34426,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         conversion_to_mp4_successful = True
         if self.exportToVideoPreferences['filepath'].endswith('.mp4'):
             try:
-                self.exportToVideoExporter.avi_to_mp4()
+                self.exportToVideoExporter.avi_to_mp4(
+                    crf=self.exportToVideoPreferences['crf']
+                    )
                 try:
                     os.remove(self.exportToVideoPreferences['avi_filepath'])
                 except Exception as err:

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -485,8 +485,36 @@ class viewPushButton(PushButton):
 
 class infoPushButton(PushButton):
     def __init__(self, *args, **kwargs):
+        """
+        Button for displaying info. Provide `info_text` in kwargs to display a 
+        message box with the info text when clicked.
+        Provide `info_title` in kwargs to set the title of the message box. If 
+        `info_text` is not provided, the button will not display any message 
+        box.
+        """
+        if 'info_text' in kwargs:
+            self.info_text = kwargs.pop('info_text')
+        else:
+            self.info_text = None
+        if 'info_title' in kwargs:
+            self.info_title = kwargs.pop('info_title')
+        else:
+            self.info_title = 'Information'
+
         super().__init__(*args, **kwargs)
         self.setIcon(QIcon(':info.svg'))
+        if self.info_text is not None:
+            self.clicked.connect(self.show_info)
+
+        
+    def show_info(self):
+        if self.info_text is None:
+            return
+        msg = myMessageBox(parent=self.parent())
+        txt = html_utils.paragraph(self.info_text)
+        msg.information(
+            self, self.info_title, txt
+        )
 
 class threeDPushButton(PushButton):
     def __init__(self, *args, **kwargs):
@@ -4401,7 +4429,7 @@ class FloatLineEdit(QLineEdit):
             self.setValue(0)  
     
     def setDecimals(self, decimals):
-        self._decimals = 6
+        self._decimals = decimals
 
     def castMinMax(self, value: int):
         if value > self._maximum:
@@ -4456,15 +4484,17 @@ class IntLineEdit(QLineEdit):
 
     def __init__(
             self, *args, notAllowed=None, allowNegative=True, initial=None,
-            readOnly=False
+            readOnly=False, maximum=None, minimum=None
         ):
         QLineEdit.__init__(self, *args)
         self.notAllowed = notAllowed
         if readOnly:
             self.setReadOnly(readOnly)
 
-        self._maximum = np.inf
-        self._minimum = -np.inf
+        maximum = maximum if maximum is not None else np.inf
+        minimum = minimum if minimum is not None else -np.inf
+        self._maximum = maximum
+        self._minimum = minimum
         
         self._regExp = r'\d+'
         if allowNegative:


### PR DESCRIPTION
- Updates `widgets.infoPushButton` so that it can get `info_text` and `info_title` as kwargs and automatically creates a help window when clicked.
-  Add CRF option to the export dialogue so users can set quality presets

Closes #1162 