### PR TITLE
Clear merge IDs lines, closes #1170

### DIFF
--- a/cellacdc/QtScoped.py
+++ b/cellacdc/QtScoped.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import PYQT6, Qt
+from qtpy.QtCore import PYQT6, Qt, QEvent
 
 from qtpy.QtWidgets import QAbstractSlider, QStyle
 
@@ -62,7 +62,14 @@ def QStyleSC_ScrollBarSubLine():
     else:
         return QStyle.SC_ScrollBarSubLine
     
-    
+
+def QEventTypeAttribute(name: str):
+    if PYQT6:
+        return getattr(QEvent.Type, name)
+    else:
+        return getattr(QEvent, name)
+
+
 if not PYQT6:
     mouse_button_names_mapper = {
         getattr(Qt, name): name

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -429,7 +429,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.gui_createLabWidgets()
         self.gui_createBottomWidgetsToBottomLayout()
 
-        mainContainer = QWidget()
+        mainContainer = widgets.GuiCentralWidget()
         self.setCentralWidget(mainContainer)
 
         mainLayout = self.gui_createMainLayout()
@@ -443,10 +443,16 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.initShortcuts()
         self.show()
         QTimer.singleShot(100, self.resizeRangeWelcomeText)
-        # self.installEventFilter(self)
+        
+        self.app.installEventFilter(self)
         
         self.logger.info('GUI ready.')
     
+    def onMouseRelease(self):
+        if self.mergeIDsButton.isChecked() and self.xHoverImg is None:
+            # Mouse released outside of images --> clear free roi item
+            self.freeRoiItem.clear()
+
     def initGlobalAttr(self):
         self.setOverlayColors()
 
@@ -8098,6 +8104,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.isMouseDragImg1 = True
         
         elif (left_click or right_click) and canDrawMergeRegion:
+            self.freeRoiItem.clear()
+
             x, y = event.pos().x(), event.pos().y()
             xdata, ydata = int(x), int(y)
             self.freeRoiItem.addPoint(xdata, ydata)
@@ -14906,6 +14914,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 text='for the merged object.',
                 action='released the mouse button'
             )
+            if targetID is None:
+                self.freeRoiItem.clear()
+                return
         
         self.logger.info('Merging objects inside freehand region...')
         
@@ -15408,6 +15419,8 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.uncheckLeftClickButtons(self.mergeIDsButton)
             self.connectLeftClickButtons()
             self.mergeIDsToolbar.setOnlyCurrentZsliceEnabled(self.isSegm3D)
+        else:
+            self.freeRoiItem.clear()
         
         self.mergeIDsToolbar.setVisible(checked)
 
@@ -35786,3 +35799,9 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.timestamp.updatePosViewRangeChanged(viewRange)
         
         self._viewRange = viewRange
+
+    def eventFilter(self, object, event):
+        if event.type() == QtScoped.QEventTypeAttribute('MouseButtonRelease'):
+            self.onMouseRelease()
+        
+        return super().eventFilter(object, event)

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -288,9 +288,9 @@ class PushButton(QPushButton):
         self.setSizePolicy(sp)
     
     def eventFilter(self, object, event):
-        if event.type() == QEvent.Type.HoverEnter:
+        if event.type() == QtScoped.QEventTypeAttribute('HoverEnter'):
             self.setFlat(False)
-        elif event.type() == QEvent.Type.HoverLeave:
+        elif event.type() == QtScoped.QEventTypeAttribute('HoverLeave'):
             self.setFlat(True)
         return False
     
@@ -975,7 +975,7 @@ class ElidingLineEdit(QLineEdit):
         event.accept()
     
     def eventFilter(self, a0: 'QObject', a1: 'QEvent') -> bool:
-        isFocusIn = a1.type() == QEvent.Type.FocusIn
+        isFocusIn = a1.type() == QtScoped.QEventTypeAttribute('FocusIn')
         if isFocusIn and (self.isReadOnly() or not self.isEnabled()):
             self.clearFocus()
             return True
@@ -1070,12 +1070,12 @@ class ScrollBar(QScrollBar):
         self.setContextMenuPolicy(Qt.NoContextMenu)
     
     def eventFilter(self, object, event) -> bool:
-        if event.type() == QEvent.Type.Wheel:
+        if event.type() == QtScoped.QEventTypeAttribute('Wheel'):
             return True
-        elif event.type() == QEvent.Type.MouseButtonPress:
+        elif event.type() == QtScoped.QEventTypeAttribute('MouseButtonPress'):
             # Filter right-click to prevent context menu
             return event.button() == Qt.MouseButton.RightButton
-        elif event.type() == QEvent.Type.MouseButtonRelease:
+        elif event.type() == QtScoped.QEventTypeAttribute('MouseButtonRelease'):
             # Filter right-click to prevent context menu
             return event.button() == Qt.MouseButton.RightButton
         return False
@@ -1731,14 +1731,14 @@ class VerticalResizeHline(QFrame):
         return super().mouseReleaseEvent(event)
     
     def eventFilter(self, object, event):
-        if event.type() == QEvent.Type.Enter:
+        if event.type() == QtScoped.QEventTypeAttribute('Enter'):
             self.setLineWidth(0)
             self.setMidLineWidth(self._height)
             pal = self.palette()
             pal.setColor(QPalette.ColorRole.WindowText, QColor(BASE_COLOR))
             self.setPalette(pal)
             # self.setStyleSheet('background-color: #4d4d4d') 
-        elif event.type() == QEvent.Type.Leave:
+        elif event.type() == QtScoped.QEventTypeAttribute('Leave'):
             self.setMidLineWidth(0)
             self.setLineWidth(1)
         return False
@@ -1834,14 +1834,14 @@ class ScrollArea(QScrollArea):
         self.setFixedHeight(height)
 
     def eventFilter(self, object, event: QEvent):
-        if event.type() == QEvent.Type.Leave:
+        if event.type() == QtScoped.QEventTypeAttribute('Leave'):
             self.sigLeaveEvent.emit()
 
         if object != self.containerWidget:
             return False
         
-        isResize = event.type() == QEvent.Type.Resize
-        isShow = event.type() == QEvent.Type.Show
+        isResize = event.type() == QtScoped.QEventTypeAttribute('Resize')
+        isShow = event.type() == QtScoped.QEventTypeAttribute('Show')
         if isResize and self.isOnlyVertical:
             self._resizeHorizontal()
         elif isShow and self.resizeVerticalOnShow:
@@ -1887,7 +1887,7 @@ class QCenteredComboBox(QComboBox):
     
     def eventFilter(self, lineEdit, event):
         # Reimplement show popup on click
-        if event.type() == QEvent.Type.MouseButtonPress and self.isEnabled():
+        if event.type() == QtScoped.QEventTypeAttribute('MouseButtonPress') and self.isEnabled():
             if self._isPopupVisibile:
                 self.hidePopup()
                 self._isPopupVisibile = False
@@ -2325,7 +2325,7 @@ class mySpinBox(QSpinBox):
         super().__init__(*args)
     
     def event(self, event):
-        if event.type()==QEvent.Type.KeyPress and event.key() == Qt.Key_Tab:
+        if event.type()==QtScoped.QEventTypeAttribute('KeyPress') and event.key() == Qt.Key_Tab:
             self.sigTabEvent.emit(event, self)
             return True
 
@@ -3700,7 +3700,7 @@ class Toggle(QCheckBox):
     def eventFilter(self, object, event):
         # To get the actual position of the circle we need to wait that
         # the widget is visible before setting the state
-        if event.type() == QEvent.Type.Show and self.requestedState is not None:
+        if event.type() == QtScoped.QEventTypeAttribute('Show') and self.requestedState is not None:
             self.setChecked(self.requestedState)
         return False
 
@@ -3852,7 +3852,7 @@ class ShortcutLineEdit(QLineEdit):
         self._allowMouseButtons = allowMouseButtons
         
     def eventFilter(self, obj, event):
-        if event.type() == QEvent.Type.MouseButtonPress:
+        if event.type() == QtScoped.QEventTypeAttribute('MouseButtonPress'):
             button = event.button()
             if (
                     self._allowMouseButtons 
@@ -4312,7 +4312,7 @@ class ReadOnlyLineEdit(QLineEdit):
         self.installEventFilter(self)
     
     def eventFilter(self, a0: 'QObject', a1: 'QEvent') -> bool:
-        if a1.type() == QEvent.Type.FocusIn:
+        if a1.type() == QtScoped.QEventTypeAttribute('FocusIn'):
             return True
         return super().eventFilter(a0, a1)
 
@@ -5299,9 +5299,9 @@ class expandCollapseButton(PushButton):
         self.sigClicked.emit()
 
     def eventFilter(self, object, event):
-        if event.type() == QEvent.Type.HoverEnter:
+        if event.type() == QtScoped.QEventTypeAttribute('HoverEnter'):
             self.setFlat(False)
-        elif event.type() == QEvent.Type.HoverLeave:
+        elif event.type() == QtScoped.QEventTypeAttribute('HoverLeave'):
             self.setFlat(True)
         return False
 
@@ -6076,7 +6076,7 @@ class myHistogramLUTitem(baseHistogramLUTitem):
         self.sigAddTimestamp.emit(self.addTimestampAction.isChecked())
     
     def gradientMenuEventFilter(self, object, event):
-        if event.type() == QEvent.Type.MouseMove:
+        if event.type() == QtScoped.QEventTypeAttribute('MouseMove'):
             hoveredAction = self.gradient.menu.actionAt(event.pos())
             isActionEntered = (
                 hoveredAction != self.lastHoveredAction
@@ -9650,7 +9650,7 @@ class ComboBox(QComboBox):
         self.installEventFilter(self)
     
     def eventFilter(self, object, event) -> bool:
-        if object == self and event.type() == QEvent.Type.Wheel:
+        if object == self and event.type() == QtScoped.QEventTypeAttribute('Wheel'):
             # Forward event to parent so QScrollArea can scroll
             QApplication.sendEvent(self.parent(), event)
             return True  # Consume for the combo itself
@@ -12783,3 +12783,8 @@ class DummyWidget:
     
     def value(self):
         return
+
+class GuiCentralWidget(QWidget):
+    def __init__(self, parent=None, *args):
+        super().__init__(parent, *args)
+    


### PR DESCRIPTION
This PR implement the following fixes for clearing the merge IDs line, see #1170:

1. Line cleared upon deactivating the tool (also with Escape)
2. Line cleared when the mouse is released outside of images --> achieved through `self.app.installEventFilter(self)` which can be useful in the future for other signals.
3. Line cleared when a new line started without finishing the one initiated before (maybe redundant)
4. New function `cellacdc.QtScoped.QEventTypeAttribute` used in `cellacdc.widgets` to have PyQt5 and PyQt6 enum compatibility