### PR TITLE
Fix for points layer timelpase data

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -22,7 +22,7 @@ import cv2
 import traceback
 from itertools import combinations, permutations
 from collections import namedtuple
-from natsort import natsorted, natsort_keygen
+from natsort import natsorted
 # from MyWidgets import Slider, Button, MyRadioButtons
 from skimage.measure import label, regionprops
 from functools import partial
@@ -1387,21 +1387,23 @@ class AddPointsLayerDialog(QBaseDialog):
                 xColName = self.xColName.currentText()
                 yColName = self.yColName.currentText()
                 zColName = self.zColName.currentText()
-                if self.tColRequiresGroupingCheckbox.isChecked():
-                    df = df.sort_values(by=tColName, key=natsort_keygen())
-                    df['frame_i'] = df.groupby(tColName, sort=False).ngroup()
-                    tColName = 'frame_i'
+
+                tColRequiresGrouping = (
+                    self.tColRequiresGroupingCheckbox.isChecked()
+                )
 
                 self.loadedDfInfo = {
                     'filepath': tablePath,
                     't': tColName, 
                     'z': zColName, 
                     'y': yColName, 
-                    'x': xColName
+                    'x': xColName,
+                    't_col_requires_grouping': tColRequiresGrouping
                 }
                 
                 self._df_to_pointsData(
-                    df, tColName, zColName, yColName, xColName
+                    df, tColName, zColName, yColName, xColName, 
+                    tColRequiresGrouping=tColRequiresGrouping
                 )
                     
             except Exception as e:
@@ -1472,9 +1474,12 @@ class AddPointsLayerDialog(QBaseDialog):
         self.keySequence = shortcutWidget.widget.keySequence
         self.close()
     
-    def _df_to_pointsData(self, df, tColName, zColName, yColName, xColName):
+    def _df_to_pointsData(
+            self, df, tColName, zColName, yColName, xColName, 
+            tColRequiresGrouping=False
+        ):
         self.pointsData = load.loaded_df_to_points_data(
-            df, tColName, zColName, yColName, xColName
+            df, tColName, zColName, yColName, xColName, t_col_requires_grouping=tColRequiresGrouping
         )
     
     def showEvent(self, event) -> None:

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -34,9 +34,7 @@ import skimage.draw
 import skimage.registration
 import skimage.color
 import skimage.segmentation
-from matplotlib.backends.backend_tkagg import (
-    FigureCanvasTkAgg, NavigationToolbar2Tk
-)
+
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -22,7 +22,7 @@ import cv2
 import traceback
 from itertools import combinations, permutations
 from collections import namedtuple
-from natsort import natsorted
+from natsort import natsorted, natsort_keygen
 # from MyWidgets import Slider, Button, MyRadioButtons
 from skimage.measure import label, regionprops
 from functools import partial
@@ -1011,17 +1011,37 @@ class AddPointsLayerDialog(QBaseDialog):
         self.tColName = widgets.QCenteredComboBox()
         self.tColName.addItem('None')
         self.tColName.label = QLabel('Frame index column: ')
+        self.tColRequiresGroupingCheckbox = QCheckBox('Group by unique values')
         layout.addWidget(self.tColName.label, row, 1)
         layout.addWidget(self.tColName, row, 2)
+        layout.addWidget(self.tColRequiresGroupingCheckbox, row, 4)
         self.fromTableRadiobutton.widgets.append(self.tColName)
         sectionWidgets.append(self.tColName.label)
         sectionWidgets.append(self.tColName)
+
+        tColNameTooltip = (
+'Select the column containing the frame index (starting from 0).\n\n'
+'Alternatively, you can select any column whose values identify the rows '
+'belonging to each frame.\n'
+'Each unique value is treated as a separate frame and assigned a frame index according to its order in the table.\n\n'
+'In the latter case, make sure to check the "Group by unique values" checkbox.'
+        )
+        self.tColName.label.setToolTip(tColNameTooltip)
+        self.tColName.setToolTip(tColNameTooltip)
+
+        tColGroupCheckboxTooltip = (
+'Check this box if the selected column does not contain frame indices, '
+'but rather contains values that identify the rows belonging to each frame.\n\n'
+'Each unique value will be treated as a separate frame and assigned a frame index according to its order in the table.'
+        )
+        self.tColRequiresGroupingCheckbox.setToolTip(tColGroupCheckboxTooltip)
 
         if SizeT == 1:
             self.tColName.clear()
             self.tColName.addItem('None')
             self.tColName.label.setVisible(False)
             self.tColName.setVisible(False)
+            self.tColRequiresGroupingCheckbox.setVisible(False)
         
         self.fromTableRadiobutton.toggled.connect(self.enableRadioButtonWidgets)
         self.enableRadioButtonWidgets(False, sender=self.fromTableRadiobutton)
@@ -1363,7 +1383,11 @@ class AddPointsLayerDialog(QBaseDialog):
                 xColName = self.xColName.currentText()
                 yColName = self.yColName.currentText()
                 zColName = self.zColName.currentText()
-                
+                if self.tColRequiresGroupingCheckbox.isChecked():
+                    df = df.sort_values(by=tColName, key=natsort_keygen())
+                    df['frame_i'] = df.groupby(tColName, sort=False).ngroup()
+                    tColName = 'frame_i'
+
                 self.loadedDfInfo = {
                     'filepath': tablePath,
                     't': tColName, 

--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -1016,8 +1016,12 @@ class AddPointsLayerDialog(QBaseDialog):
         layout.addWidget(self.tColName, row, 2)
         layout.addWidget(self.tColRequiresGroupingCheckbox, row, 4)
         self.fromTableRadiobutton.widgets.append(self.tColName)
+        self.fromTableRadiobutton.widgets.append(
+            self.tColRequiresGroupingCheckbox
+        )
         sectionWidgets.append(self.tColName.label)
         sectionWidgets.append(self.tColName)
+        sectionWidgets.append(self.tColRequiresGroupingCheckbox)
 
         tColNameTooltip = (
 'Select the column containing the frame index (starting from 0).\n\n'

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -26206,11 +26206,18 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
                 if not os.path.exists(filepath):
                     action.pointsData[self.pos_i] = {}
                 
-                df = load.load_df_points_layer(filepath)                
+                df = load.load_df_points_layer(filepath)    
+                t_col_requires_grouping = (
+                    action.loadedDfInfo.get('t_col_requires_grouping', False)
+                )            
                 action.pointsData[self.pos_i] = (
                     load.loaded_df_to_points_data(
-                        df, action.loadedDfInfo['t'], action.loadedDfInfo['z'], 
-                        action.loadedDfInfo['y'], action.loadedDfInfo['x']
+                        df, 
+                        action.loadedDfInfo['t'], 
+                        action.loadedDfInfo['z'], 
+                        action.loadedDfInfo['y'], 
+                        action.loadedDfInfo['x'],
+                        t_col_requires_grouping=t_col_requires_grouping
                     )
                 )
                 self.logLoadedTablePointsLayer(df, filename=filename)

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -25899,6 +25899,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             hideFromTableSection=onlyMouseClicks,
             hideManualEntrySection=onlyMouseClicks,
             hideWithMouseClicksSection=False,
+            SizeT=posData.SizeT,
             parent=self,
         )
         cmap = matplotlib.colormaps['gist_rainbow']
@@ -25931,12 +25932,12 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
     
     def logLoadedTablePointsLayer(self, df, filename: str):
         separator = f'-'*100
-        header = f'First 10 rows of loaded table - "{filename}":'
+        header = f'First 10 rows and 10 columns of loaded table - "{filename}":'
         footer = f'Number of points: {len(df)}'
         text = (
             f'{separator}\n'
             f'{header}\n\n'
-            f'{df.head(10)}\n\n'
+            f'{df.iloc[:10, :10]}\n\n'
             f'{footer}\n'
             f'{separator}'
         )
@@ -26186,6 +26187,7 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
         self.pointsLayerClicksDfsToData(posData)
     
     def pointsLayerLoadedDfsToData(self):
+        self.logger.info('Generating points data from table...')
         posData = self.data[self.pos_i]
         for toolbar in self.pointsLayersToolbars:
             for action in toolbar.actions()[1:]:

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4494,10 +4494,10 @@ def loaded_df_to_points_data(df, t_col, z_col, y_col, x_col):
                 }
         else:
             points_data[frame_i] = {
-                'x': df[x_col].to_list(),
-                'y': df[y_col].to_list(), 
-                'id': df['id'].to_list(), 
-                'data': [row.to_string() for _, row in df.iterrows()]
+                'x': df_frame[x_col].to_list(),
+                'y': df_frame[y_col].to_list(), 
+                'id': df_frame['id'].to_list(), 
+                'data': [row.to_string() for _, row in df_frame.iterrows()]
             }
     return points_data
 

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -4474,7 +4474,7 @@ def loaded_df_to_points_data(df, t_col, z_col, y_col, x_col):
         grouped = df.groupby(t_col)
     else:
         grouped = [(0, df)]
-    
+
     for frame_i, df_frame in grouped:
         if z_col != 'None':
             df_frame[z_col] = df_frame[z_col].round().astype(int)
@@ -4509,8 +4509,18 @@ def load_df_points_layer(filepath):
         with pd.HDFStore(filepath) as h5:
             keys = h5.keys()
             dfs = [h5.get(key) for key in keys]
-        df = pd.concat(dfs, keys=keys, names=['h5_key'])
-    return df
+        df = pd.concat(dfs, keys=keys, names=['h5_key']).reset_index()
+        try:
+            df['frame_i'] = (
+                df['h5_key'].str.extract(r'/frame_(\d+)').astype(int)
+            )
+        except Exception as e:
+            from .config import parser_args
+            debug = parser_args['debug']
+            if debug:
+                traceback.print_exc()
+            pass
+    return df.reset_index()
 
 def get_unique_exp_paths(paths: List):
     unique_exp_paths = set()

--- a/cellacdc/load.py
+++ b/cellacdc/load.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from tifffile import TiffFile
 import tifffile
 import zipfile
-from natsort import natsorted
+from natsort import natsorted, natsort_keygen
 import time
 
 from functools import partial
@@ -4465,7 +4465,14 @@ def save_df_to_csv_temp_path(df, csv_filename, **to_csv_kwargs):
     df.to_csv(tempFilepath, **to_csv_kwargs)
     return tempFilepath
 
-def loaded_df_to_points_data(df, t_col, z_col, y_col, x_col):
+def loaded_df_to_points_data(
+        df, t_col, z_col, y_col, x_col, t_col_requires_grouping=False
+    ):
+    if t_col_requires_grouping:
+        df = df.sort_values(by=t_col, key=natsort_keygen())
+        df['frame_i'] = df.groupby(t_col, sort=False).ngroup()
+        t_col = 'frame_i'
+
     points_data = {}
     if 'id' not in df.columns:
         df['id'] = ''


### PR DESCRIPTION
This PR implements fixes for #1179 and adds the following feature:

- Allow selecting a column that contains the time information. This column (called `tColName`) will be used to generate the `frame_i` column as follows:
```python
df = df.sort_values(by=tColName, key=natsort_keygen())
df['frame_i'] = df.groupby(tColName, sort=False).ngroup()
```

This results in a new `frame_i` column where each unique value is treated as a separate frame and assigned a frame index according to its order in the table. This can be useful to use columns such as `time_seconds`, or `time_minutes` or string identifiers such as `frame_0` as the frame index where the points come from. 