### PR TITLE
Fix for cell tracking order of IDs_prev and IDs_curr_untracked in calc_Io_matrix

### DIFF
--- a/cellacdc/_warnings.py
+++ b/cellacdc/_warnings.py
@@ -481,7 +481,7 @@ def warnAskAboutSaveSingleMotherBudPairsCcaDf(
         qparent, 'Partial cell cycle annotations', txt,
         buttonsTexts=(
             widgets.noPushButton('Save only fully annotated frames'),
-            widgets.savePushButton('Save partially annotated frames')
+            widgets.savePushButton('Save also partially annotated frames')
         ),
         detailsText=detailsText,
         details_expanded=False

--- a/cellacdc/trackers/CellACDC/CellACDC_tracker.py
+++ b/cellacdc/trackers/CellACDC/CellACDC_tracker.py
@@ -75,9 +75,7 @@ def calc_Io_matrix(
     from cellacdc.regionprops import acdcRegionprops
 
     specific_IDs = _normalize_specific_IDs(specific_IDs)
-    if IDs_curr_untracked is None and isinstance(rp, acdcRegionprops):
-        IDs_curr_untracked = rp.IDs
-    elif IDs_curr_untracked is None:
+    if IDs_curr_untracked is None:
         IDs_curr_untracked = [obj.label for obj in rp]
     elif not isinstance(IDs_curr_untracked, list):
         IDs_curr_untracked = list(IDs_curr_untracked)
@@ -87,11 +85,7 @@ def calc_Io_matrix(
             ID for ID in IDs_curr_untracked if ID in specific_IDs
         ]
 
-    if isinstance(prev_rp, acdcRegionprops):
-        IDs_prev = prev_rp.IDs
-    
-    else:
-        IDs_prev = [obj.label for obj in prev_rp]
+    IDs_prev = [obj.label for obj in prev_rp]
 
     if not IDs_curr_untracked:
         return np.zeros((0, len(prev_rp))), IDs_curr_untracked, IDs_prev
@@ -135,7 +129,8 @@ def calc_Io_matrix(
     IoA_matrix = np.zeros((len(IDs_curr_untracked), len(prev_rp)))
     rp_mapper = {obj.label: obj for obj in rp}
     idx_mapper = {ID: i for i, ID in enumerate(IDs_curr_untracked)}
-    for j, obj_prev in enumerate(prev_rp):
+    idx_prev_mapper = {obj.label: i for i, obj in enumerate(prev_rp)}
+    for obj_prev in prev_rp:
         if denom == 'area_prev':
             denom_val = obj_prev.area
         intersect_IDs, intersects = np.unique(
@@ -152,9 +147,10 @@ def calc_Io_matrix(
                 if denom_val == 0:
                     continue
             idx = idx_mapper.get(intersect_ID)
+            idx_prev = idx_prev_mapper.get(obj_prev.label)
             if idx is None:
                 continue
-            IoA_matrix[idx, j] = I / denom_val
+            IoA_matrix[idx, idx_prev] = I / denom_val
     return IoA_matrix, IDs_curr_untracked, IDs_prev
 
 def assign(
@@ -449,7 +445,6 @@ def track_frame(
         IoA_thresh_aggr=IoA_thresh_aggr, daughters_list=daughters_list,
         specific_IDs=specific_IDs,
     )
-    
     if posData is None and unique_ID is None:
         unique_ID = max(
             (max(IDs_prev, default=0), max(all_curr_IDs, default=0))

--- a/cellacdc/trackers/CellACDC/CellACDC_tracker.py
+++ b/cellacdc/trackers/CellACDC/CellACDC_tracker.py
@@ -72,9 +72,7 @@ def calc_Io_matrix(
         specific_IDs=None,
         denom: str='area_prev'
     ):
-    from cellacdc.regionprops import acdcRegionprops
-
-    specific_IDs = _normalize_specific_IDs(specific_IDs)
+specific_IDs = _normalize_specific_IDs(specific_IDs)
     if IDs_curr_untracked is None:
         IDs_curr_untracked = [obj.label for obj in rp]
     elif not isinstance(IDs_curr_untracked, list):

--- a/cellacdc/trackers/CellACDC/CellACDC_tracker.py
+++ b/cellacdc/trackers/CellACDC/CellACDC_tracker.py
@@ -72,7 +72,7 @@ def calc_Io_matrix(
         specific_IDs=None,
         denom: str='area_prev'
     ):
-specific_IDs = _normalize_specific_IDs(specific_IDs)
+    specific_IDs = _normalize_specific_IDs(specific_IDs)
     if IDs_curr_untracked is None:
         IDs_curr_untracked = [obj.label for obj in rp]
     elif not isinstance(IDs_curr_untracked, list):

--- a/cellacdc/trackers/CellACDC/CellACDC_tracker.py
+++ b/cellacdc/trackers/CellACDC/CellACDC_tracker.py
@@ -129,8 +129,7 @@ def calc_Io_matrix(
     IoA_matrix = np.zeros((len(IDs_curr_untracked), len(prev_rp)))
     rp_mapper = {obj.label: obj for obj in rp}
     idx_mapper = {ID: i for i, ID in enumerate(IDs_curr_untracked)}
-    idx_prev_mapper = {obj.label: i for i, obj in enumerate(prev_rp)}
-    for obj_prev in prev_rp:
+    for idx_prev, obj_prev in enumerate(prev_rp):
         if denom == 'area_prev':
             denom_val = obj_prev.area
         intersect_IDs, intersects = np.unique(
@@ -147,7 +146,6 @@ def calc_Io_matrix(
                 if denom_val == 0:
                     continue
             idx = idx_mapper.get(intersect_ID)
-            idx_prev = idx_prev_mapper.get(obj_prev.label)
             if idx is None:
                 continue
             IoA_matrix[idx, idx_prev] = I / denom_val

--- a/tests/test_cellacdc_tracker_specific_ids.py
+++ b/tests/test_cellacdc_tracker_specific_ids.py
@@ -32,8 +32,8 @@ def test_calc_io_matrix_uses_regionprops_iteration_order_for_axes():
         ioa_matrix, current_ids, previous_ids
     )
 
-assert current_ids == [obj.label for obj in rp]
-assert previous_ids == [obj.label for obj in prev_rp]
+    assert current_ids == [obj.label for obj in rp]
+    assert previous_ids == [obj.label for obj in prev_rp]
     assert dict(zip(old_ids, tracked_ids)) == {1: 2, 2: 7, 7: 8, 8: 1}
 
 

--- a/tests/test_cellacdc_tracker_specific_ids.py
+++ b/tests/test_cellacdc_tracker_specific_ids.py
@@ -32,8 +32,8 @@ def test_calc_io_matrix_uses_regionprops_iteration_order_for_axes():
         ioa_matrix, current_ids, previous_ids
     )
 
-    assert current_ids == [1, 2, 7, 8]
-    assert previous_ids == [1, 2, 7, 8]
+assert current_ids == [obj.label for obj in rp]
+assert previous_ids == [obj.label for obj in prev_rp]
     assert dict(zip(old_ids, tracked_ids)) == {1: 2, 2: 7, 7: 8, 8: 1}
 
 

--- a/tests/test_cellacdc_tracker_specific_ids.py
+++ b/tests/test_cellacdc_tracker_specific_ids.py
@@ -1,9 +1,40 @@
 import numpy as np
 from skimage.measure import regionprops
 
+from cellacdc.regionprops import acdcRegionprops
 from cellacdc.trackers.CellACDC import CellACDC_tracker
 from cellacdc.trackers.CellACDC_2steps.CellACDC_2steps_tracker import tracker as TwoStepsTracker
 from cellacdc.trackers.CellACDC_normal_division.CellACDC_normal_division_tracker import tracker as NormalDivisionTracker
+
+
+def test_calc_io_matrix_uses_regionprops_iteration_order_for_axes():
+    prev_lab = np.array(
+        [
+            [1, 2],
+            [7, 8],
+        ],
+        dtype=np.uint16,
+    )
+    lab = np.array(
+        [
+            [8, 1],
+            [2, 7],
+        ],
+        dtype=np.uint16,
+    )
+    prev_rp = acdcRegionprops(prev_lab, precache_centroids=False)
+    rp = acdcRegionprops(lab, precache_centroids=False)
+
+    ioa_matrix, current_ids, previous_ids = CellACDC_tracker.calc_Io_matrix(
+        lab, prev_lab, rp, prev_rp
+    )
+    old_ids, tracked_ids = CellACDC_tracker.assign(
+        ioa_matrix, current_ids, previous_ids
+    )
+
+    assert current_ids == [1, 2, 7, 8]
+    assert previous_ids == [1, 2, 7, 8]
+    assert dict(zip(old_ids, tracked_ids)) == {1: 2, 2: 7, 7: 8, 8: 1}
 
 
 def test_track_frame_specific_ids_only_tracks_requested_current_ids():


### PR DESCRIPTION
- I changed how the IDs from rp are retrieved directly from the acdc rp
- Created problems with keeping track of matrix index and IDs
- Now just create a list from scratch 