### PR TITLE
Move related folder when moving `.vsi` files data struct module

### DIFF
--- a/cellacdc/apps.py
+++ b/cellacdc/apps.py
@@ -13453,6 +13453,9 @@ class QDialogModelParams(QDialog):
         heightInitParams = (
             self.initParamsScrollArea.minimumHeightNoScrollbar()
         )
+        self.initParamsScrollArea.setMinimumHeight(
+            heightInitParams
+        )
         heightLeft = 70 + buttonHeight
         heightCenter = heightInitParams
         heightRight = 0

--- a/cellacdc/dataStruct.py
+++ b/cellacdc/dataStruct.py
@@ -1167,11 +1167,8 @@ class bioFormatsWorker(QObject):
         
         rawFilePath = os.path.join(self.raw_src_path, filename)
         raw_path = os.path.join(raw_src_path, 'raw_microscopy_files')
-        if not os.path.exists(raw_path):
-            os.mkdir(raw_path)
-        dst = os.path.join(raw_path, filename)
         try:
-            shutil.move(rawFilePath, dst)
+            io.move_raw_microscopy_file(rawFilePath, raw_path)
             return raw_path
         except PermissionError as e:
             self.progress.emit(e)

--- a/cellacdc/io.py
+++ b/cellacdc/io.py
@@ -271,6 +271,8 @@ def move_raw_microscopy_file(
         return dst_filepath
 
     shutil.move(src_related_folderpath, dst_folderpath)
+
+    return dst_filepath
     
 
     

--- a/cellacdc/io.py
+++ b/cellacdc/io.py
@@ -250,3 +250,27 @@ def move_separate_channels_tiffs_to_pos_folders(
                 except Exception as err:
                     pass
     return True
+
+def move_raw_microscopy_file(
+        src_filepath: os.PathLike,
+        dst_folderpath: os.PathLike,
+    ):
+    if not os.path.exists(dst_folderpath):
+        os.mkdir(dst_folderpath)
+
+    src_folderpath = os.path.dirname(src_filepath)
+    filename = os.path.basename(src_filepath)
+    filename_noext, ext = os.path.splitext(filename)
+    dst_filepath = os.path.join(dst_folderpath, filename)
+
+    shutil.move(src_filepath, dst_filepath)
+
+    src_related_folderpath = os.path.join(src_folderpath, f'_{filename_noext}_')
+
+    if not os.path.exists(src_related_folderpath):
+        return dst_filepath
+
+    shutil.move(src_related_folderpath, dst_folderpath)
+    
+
+    


### PR DESCRIPTION
When working with Olympus `.vsi` files, there is a related folder called `_filename_` that needs to be moved together with the `.vsi` file, otherwise the raw data is corrupted.

This PR adds a fix for that by moving the folder as well (if moving is requested by the user during the setup of the data structure module). 