### PR TITLE
Lock view button data prep, see #1185

### DIFF
--- a/cellacdc/dataPrep.py
+++ b/cellacdc/dataPrep.py
@@ -440,11 +440,6 @@ class dataPrepWin(QMainWindow):
             'File --> Open or Open recent to start the process')
         self.graphLayout.addItem(self.titleLabel, row=0, col=1)
 
-        # Current frame text
-        # self.frameLabel = pg.LabelItem(justify='center', color='w', size='14pt')
-        # self.frameLabel.setText(' ')
-        # self.graphLayout.addItem(self.frameLabel, row=2, col=1)
-
     def gui_addPlotItems(self):
         # Image Item
         # blankImage = np.full((512,512,3), darkBkgrColor)
@@ -454,7 +449,6 @@ class dataPrepWin(QMainWindow):
 
     def removeAllItems(self):
         self.ax1.clear()
-        # self.frameLabel.setText(' ')
 
     def removeFreeRoi(self):
         self.freeRoiItem.clear()
@@ -506,7 +500,11 @@ class dataPrepWin(QMainWindow):
         self.zProjLockViewButton = widgets.LockPushButton()
         self.zProjLockViewButton.setCheckable(True)
         self.zProjLockViewButton.setToolTip(
-            'If active, the selected z-slice view is applied to all frames'
+            'If active (lock closed), '
+            'the selected z-slice view is applied to all frames or Positions.\n\n'
+            'IMPORTANT: The z-slice/projection mode are stored as the view '
+            'to use for segmentation\n'
+            'only when you visit the frame/Position.'
         )
         self.zProjLockViewButton.setDisabled(True)
 
@@ -605,9 +603,6 @@ class dataPrepWin(QMainWindow):
     def updateNavigateItems(self):
         posData = self.data[self.pos_i]
         if self.num_pos > 1:
-            # self.frameLabel.setText(
-            #          f'Current position = {self.pos_i+1}/{self.num_pos} '
-            #          f'({posData.pos_foldername})')
             self.navigateSB_label.setText(f'Pos n. {self.pos_i+1}')
             try:
                 self.navigateScrollbar.valueChanged.disconnect()
@@ -615,8 +610,6 @@ class dataPrepWin(QMainWindow):
                 pass
             self.navigateScrollbar.setValue(self.pos_i+1)
         else:
-            # self.frameLabel.setText(
-            #          f'Current frame = {self.frame_i+1}/{self.num_frames}')
             self.navigateSB_label.setText(f'frame n. {self.frame_i+1}')
             try:
                 self.navigateScrollbar.valueChanged.disconnect()
@@ -2144,6 +2137,9 @@ class dataPrepWin(QMainWindow):
         return True
 
     def init_segmInfo_df(self):
+        self._saving_segmInfo_df = False
+        self._save_segmInfo_pending = False
+        
         self.pos_i = 0
         self.frame_i = 0
         for posData in self.data:
@@ -2163,7 +2159,7 @@ class dataPrepWin(QMainWindow):
         posData = self.data[0]
         qutils.tryDisconnectSignal(self.zSliceScrollBar, 'valueChanged')
         qutils.tryDisconnectSignal(self.zProjComboBox, 'currentTextChanged')
-        qutils.tryDisconnectSignal(self.zProjLockViewButton, 'toggled')
+        qutils.tryDisconnectSignal(self.zProjLockViewButton, 'sigToggled')
         if posData.SizeZ > 1:
             self.z_label.setDisabled(False)
             self.zSliceScrollBar.setDisabled(False)
@@ -2172,7 +2168,9 @@ class dataPrepWin(QMainWindow):
             self.zSliceScrollBar.setMaximum(posData.SizeZ-1)
             self.zSliceScrollBar.valueChanged.connect(self.update_z_slice)
             self.zProjComboBox.currentTextChanged.connect(self.updateZproj)
-            self.zProjLockViewButton.toggled.connect(self.zProjLockViewToggled)
+            self.zProjLockViewButton.sigToggled.connect(
+                self.zProjLockViewToggled
+            )
             if posData.SizeT > 1:
                 self.interpAction.setEnabled(True)
             self.ZbackAction.setEnabled(True)
@@ -2194,31 +2192,54 @@ class dataPrepWin(QMainWindow):
             idx = (posData.filename, self.frame_i)
             posData.segmInfo_df.at[idx, 'z_slice_used_dataPrep'] = z
             self.update_img()
-            posData.segmInfo_df.to_csv(posData.segmInfo_df_csv_path)
+            self.save_segmInfo_df_pos()
 
 
     def updateZproj(self, how):
         posData = self.data[self.pos_i]
+        idx = (posData.filename, self.frame_i)
+        posData.segmInfo_df.at[idx, 'which_z_proj'] = how
+        
         if how == 'single z-slice':
             self.zSliceScrollBar.setDisabled(False)
-            self.z_label.setStyleSheet('color: black')
+            self.z_label.setStyleSheet(None)
             self.update_z_slice(self.zSliceScrollBar.sliderPosition())
         else:
             self.zSliceScrollBar.setDisabled(True)
             self.z_label.setStyleSheet('color: gray')
             self.update_img()
 
+        self.save_segmInfo_df_pos()
+
+    def saveSegmInfoDfWorkerFinished(self):
+        self._saving_segmInfo_df = False
+
+        if self._save_segmInfo_pending:
+            self._save_segmInfo_pending = False
+            self.save_segmInfo_df_pos()
+        
     def save_segmInfo_df_pos(self):
-        # Launch a separate thread to save to csv and keep gui responsive
+        # If a save is already running, just mark that another save is pending.
+        if self._saving_segmInfo_df:
+            self._save_segmInfo_pending = True
+            return
+
+        self._save_segmInfo_pending = False
+        self._saving_segmInfo_df = True
+
         thread = QThread()
         worker = toCsvWorker()
         worker.setData(self.data)
         worker.moveToThread(thread)
+
         thread.started.connect(worker.run)
         worker.finished.connect(thread.quit)
         worker.finished.connect(worker.deleteLater)
+        worker.finished.connect(self.saveSegmInfoDfWorkerFinished)
         thread.finished.connect(thread.deleteLater)
+
         thread.start()
+
         self.saveSegmInfoWorkers.append((thread, worker))
 
     def useSameZ_fromHereBack(self, event):

--- a/cellacdc/dataPrep.py
+++ b/cellacdc/dataPrep.py
@@ -43,6 +43,7 @@ from . import autopilot, workers
 from . import recentPaths_path
 from . import urls
 from . import io
+from . import qutils
 from .help import about
 from . import fonts
 
@@ -502,13 +503,27 @@ class dataPrepWin(QMainWindow):
                                      'median z-proj.'])
         self.zProjComboBox.setDisabled(True)
 
+        self.zProjLockViewButton = widgets.LockPushButton()
+        self.zProjLockViewButton.setCheckable(True)
+        self.zProjLockViewButton.setToolTip(
+            'If active, the selected z-slice view is applied to all frames'
+        )
+        self.zProjLockViewButton.setDisabled(True)
+
         self.img_Widglayout.addWidget(navSB_label, 0, 0, alignment=Qt.AlignCenter)
-        self.img_Widglayout.addWidget(self.navigateScrollbar, 0, 1, 1, 30)
+        self.img_Widglayout.addWidget(self.navigateScrollbar, 0, 1)
 
         self.img_Widglayout.addWidget(_z_label, 1, 0, alignment=Qt.AlignCenter)
-        self.img_Widglayout.addWidget(self.zSliceScrollBar, 1, 1, 1, 30)
+        self.img_Widglayout.addWidget(self.zSliceScrollBar, 1, 1)
 
-        self.img_Widglayout.addWidget(self.zProjComboBox, 1, 31, 1, 1)
+        self.img_Widglayout.addWidget(self.zProjComboBox, 1, 2)
+
+        self.img_Widglayout.addWidget(self.zProjLockViewButton, 1, 3)
+
+        self.img_Widglayout.setColumnStretch(0, 0)
+        self.img_Widglayout.setColumnStretch(1, 1)
+        self.img_Widglayout.setColumnStretch(2, 0)
+        self.img_Widglayout.setColumnStretch(3, 0)
 
         self.img_Widglayout.setContentsMargins(100, 0, 20, 0)
 
@@ -612,6 +627,51 @@ class dataPrepWin(QMainWindow):
             self.navigateScrollbarValueChanged
         )
 
+    def zSlice(self, posData, frame_i):
+        df = posData.segmInfo_df
+        idx = (posData.filename, frame_i)
+        try:
+            stored_z = df.at[idx, 'z_slice_used_dataPrep']
+        except Exception as e:
+            duplicated_idx = df.index.duplicated()
+            posData.segmInfo_df = df[~duplicated_idx]
+            stored_z = posData.segmInfo_df.at[idx, 'z_slice_used_dataPrep']
+        
+        if not self.zProjLockViewButton.isChecked():
+            self.zSliceScrollBar.blockSignals(True)
+            self.zSliceScrollBar.setSliderPosition(stored_z)
+            self.zSliceScrollBar.blockSignals(False)
+            return stored_z
+        
+        current_z = self.zSliceScrollBar.sliderPosition()
+        if stored_z == current_z:
+            return stored_z
+        
+        # With lock button we use the z-slice of the slider and we store it
+        posData.segmInfo_df.at[idx, 'z_slice_used_dataPrep'] = current_z
+        self.save_segmInfo_df_pos()
+
+        return current_z
+
+    def zProjHow(self, posData, frame_i):
+        idx = (posData.filename, frame_i)
+        storedZprojHow = posData.segmInfo_df.at[idx, 'which_z_proj']
+        if not self.zProjLockViewButton.isChecked():
+            self.zProjComboBox.blockSignals(True)
+            self.zProjComboBox.setCurrentText(storedZprojHow)
+            self.zProjComboBox.blockSignals(False)
+            return storedZprojHow
+        
+        currentZprojHow = self.zProjComboBox.currentText()
+        if storedZprojHow == currentZprojHow:
+            return storedZprojHow
+        
+        # With lock button we use the projection of the combobox and we store it
+        posData.segmInfo_df.at[idx, 'which_z_proj'] = currentZprojHow
+        self.save_segmInfo_df_pos()
+
+        return currentZprojHow
+
     def getImage(self, posData, img_data, frame_i, force_z=None):
         if posData.SizeT > 1:
             img = img_data[frame_i].copy()
@@ -622,27 +682,12 @@ class dataPrepWin(QMainWindow):
                 self.z_label.setText(f'z-slice  {force_z+1}/{posData.SizeZ}')
                 img = img[force_z]
                 return img
+            
             df =  posData.segmInfo_df
             idx = (posData.filename, frame_i)
-            try:
-                z = df.at[idx, 'z_slice_used_dataPrep']
-            except Exception as e:
-                duplicated_idx = df.index.duplicated()
-                posData.segmInfo_df = df[~duplicated_idx]
-                z = posData.segmInfo_df.at[idx, 'z_slice_used_dataPrep']
-                
-            zProjHow = posData.segmInfo_df.at[idx, 'which_z_proj']
-            try:
-                self.zProjComboBox.currentTextChanged.disconnect()
-            except TypeError:
-                pass
-            self.zProjComboBox.setCurrentText(zProjHow)
-            self.zProjComboBox.currentTextChanged.connect(self.updateZproj)
-
+            z = self.zSlice(posData, frame_i)
+            zProjHow = self.zProjHow(posData, frame_i)
             if zProjHow == 'single z-slice':
-                self.zSliceScrollBar.valueChanged.disconnect()
-                self.zSliceScrollBar.setSliderPosition(z)
-                self.zSliceScrollBar.valueChanged.connect(self.update_z_slice)
                 self.z_label.setText(f'z-slice  {z+1}/{posData.SizeZ}')
                 img = img[z]
             elif zProjHow == 'max z-projection':
@@ -652,6 +697,9 @@ class dataPrepWin(QMainWindow):
             elif zProjHow == 'median z-proj.':
                 img = np.median(img, axis=0)
         return img
+
+    def zProjLockViewToggled(self, checked):
+        ...
 
     @exception_handler
     def update_img(self):
@@ -1418,18 +1466,18 @@ class dataPrepWin(QMainWindow):
             self.cropZtool = None
     
     def cropZtoolvalueChanged(self, whichZ, z):
-        self.zSliceScrollBar.valueChanged.disconnect()
+        self.zSliceScrollBar.blockSignals(True)
         self.zSliceScrollBar.setValue(z)
-        self.zSliceScrollBar.valueChanged.connect(self.update_z_slice)
+        self.zSliceScrollBar.blockSignals(False)
         posData = self.data[self.pos_i]
         img = self.getImage(posData, posData.img_data, self.frame_i, force_z=z)
         self.img.setImage(img)
 
     def cropZtoolReset(self):
         posData = self.data[self.pos_i]
-        self.cropZtool.sigZvalueChanged.disconnect()
+        self.cropZtool.blockSignals(True)
         self.cropZtool.updateScrollbars(0, posData.SizeZ)
-        self.cropZtool.sigZvalueChanged.connect(self.cropZtoolvalueChanged)
+        self.cropZtool.blockSignals(False)
 
     def updateCropZtool(self):
         posData = self.data[self.pos_i]
@@ -1448,9 +1496,9 @@ class dataPrepWin(QMainWindow):
         except KeyError:
             upper_z = posData.SizeZ
 
-        self.cropZtool.sigZvalueChanged.disconnect()
+        self.cropZtool.blockSignals(True)
         self.cropZtool.updateScrollbars(lower_z, upper_z)
-        self.cropZtool.sigZvalueChanged.connect(self.cropZtoolvalueChanged)
+        self.cropZtool.blockSignals(False)
 
     def cropZtoolClosed(self):
         self.cropZtool = None
@@ -2113,18 +2161,18 @@ class dataPrepWin(QMainWindow):
                 posData.segmInfo_df.to_csv(posData.segmInfo_df_csv_path)
 
         posData = self.data[0]
-        try:
-            self.zSliceScrollBar.valueChanged.disconnect()
-            self.zProjComboBox.currentTextChanged.disconnect()
-        except Exception as e:
-            pass
+        qutils.tryDisconnectSignal(self.zSliceScrollBar, 'valueChanged')
+        qutils.tryDisconnectSignal(self.zProjComboBox, 'currentTextChanged')
+        qutils.tryDisconnectSignal(self.zProjLockViewButton, 'toggled')
         if posData.SizeZ > 1:
             self.z_label.setDisabled(False)
             self.zSliceScrollBar.setDisabled(False)
             self.zProjComboBox.setDisabled(False)
+            self.zProjLockViewButton.setDisabled(False)
             self.zSliceScrollBar.setMaximum(posData.SizeZ-1)
             self.zSliceScrollBar.valueChanged.connect(self.update_z_slice)
             self.zProjComboBox.currentTextChanged.connect(self.updateZproj)
+            self.zProjLockViewButton.toggled.connect(self.zProjLockViewToggled)
             if posData.SizeT > 1:
                 self.interpAction.setEnabled(True)
             self.ZbackAction.setEnabled(True)
@@ -2137,6 +2185,7 @@ class dataPrepWin(QMainWindow):
             self.zSliceScrollBar.setDisabled(True)
             self.zProjComboBox.setDisabled(True)
             self.z_label.setDisabled(True)
+            self.zProjLockViewButton.setDisabled(True)
 
     def update_z_slice(self, z):
         if self.zProjComboBox.currentText() == 'single z-slice':
@@ -2144,18 +2193,12 @@ class dataPrepWin(QMainWindow):
             df = posData.segmInfo_df
             idx = (posData.filename, self.frame_i)
             posData.segmInfo_df.at[idx, 'z_slice_used_dataPrep'] = z
-            posData.segmInfo_df.at[idx, 'z_slice_used_gui'] = z
             self.update_img()
             posData.segmInfo_df.to_csv(posData.segmInfo_df_csv_path)
 
 
     def updateZproj(self, how):
         posData = self.data[self.pos_i]
-        for frame_i in range(self.frame_i, posData.SizeT):
-            df = posData.segmInfo_df
-            idx = (posData.filename, self.frame_i)
-            posData.segmInfo_df.at[idx, 'which_z_proj'] = how
-            posData.segmInfo_df.at[idx, 'which_z_proj_gui'] = how
         if how == 'single z-slice':
             self.zSliceScrollBar.setDisabled(False)
             self.z_label.setStyleSheet('color: black')
@@ -2164,14 +2207,6 @@ class dataPrepWin(QMainWindow):
             self.zSliceScrollBar.setDisabled(True)
             self.z_label.setStyleSheet('color: gray')
             self.update_img()
-
-        # Apply same z-proj to future pos
-        if posData.SizeT == 1:
-            for posData in self.data[self.pos_i+1:]:
-                idx = (posData.filename, self.frame_i)
-                posData.segmInfo_df.at[idx, 'which_z_proj'] = how
-
-        self.save_segmInfo_df_pos()
 
     def save_segmInfo_df_pos(self):
         # Launch a separate thread to save to csv and keep gui responsive

--- a/cellacdc/gui.py
+++ b/cellacdc/gui.py
@@ -21612,16 +21612,15 @@ class guiWin(QMainWindow, whitelist.WhitelistGUIElements,
             self.zSliceScrollBar.setMaximum(self.data[0].SizeZ-1)
             self.zSliceSpinbox.setMaximum(self.data[0].SizeZ)
             self.SizeZlabel.setText(f'/{self.data[0].SizeZ}')
-            try:
-                self.zSliceScrollBar.actionTriggered.disconnect()
-                self.zSliceScrollBar.sliderReleased.disconnect()
-                self.zProjComboBox.currentTextChanged.disconnect()
-                self.zProjComboBox.activated.disconnect()
-                self.switchPlaneCombobox.sigPlaneChanged.disconnect()
-                self.launch3dViewerButton.toggled.disconnect()
-                self.zProjLockViewButton.toggled.disconnect()
-            except Exception as e:
-                pass
+            qutils.tryDisconnectSignal(self.zSliceScrollBar, 'actionTriggered')
+            qutils.tryDisconnectSignal(self.zSliceScrollBar, 'sliderReleased' )
+            qutils.tryDisconnectSignal(self.zProjComboBox, 'currentTextChanged')
+            qutils.tryDisconnectSignal(self.zProjComboBox, 'activated')
+            qutils.tryDisconnectSignal(
+                self.switchPlaneCombobox, 'sigPlaneChanged'
+            )
+            qutils.tryDisconnectSignal(self.launch3dViewerButton, 'toggled')
+            qutils.tryDisconnectSignal(self.zProjLockViewButton, 'toggled')
             self.zSliceScrollBar.actionTriggered.connect(
                 self.zSliceScrollBarActionTriggered
             )

--- a/cellacdc/qutils.py
+++ b/cellacdc/qutils.py
@@ -1,8 +1,10 @@
+from  typing import Literal
+import functools
+
 from qtpy.QtCore import (
     Qt, QTimer, QEventLoop
 )
 from qtpy.QtWidgets import QWidget
-import functools
 
 class QWhileLoop:
     def __init__(
@@ -130,3 +132,14 @@ def insert_row(layout, insert_at, new_widget, col=0, dont_shift_other_cols=False
                 layout.removeItem(item)
                 layout.addItem(item, row + 1, loc_col)
     layout.addWidget(new_widget, insert_at, col)
+
+def tryDisconnectSignal(
+        widget, 
+        signal, 
+        error: Literal['ignore', 'raise'] ='ignore'
+    ):
+    try:
+        getattr(widget, signal).disconnect()
+    except Exception as err:
+        if error == 'raise':
+            raise err

--- a/cellacdc/widgets.py
+++ b/cellacdc/widgets.py
@@ -358,6 +358,8 @@ class AssignNewIDButton(PushButton):
         self.setIcon(QIcon(':assign_new_id.svg'))
 
 class LockPushButton(PushButton):
+    sigToggled = Signal(bool)
+    
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setIcon(QIcon(':lock.svg'))
@@ -371,6 +373,8 @@ class LockPushButton(PushButton):
             self.setIcon(QIcon(':lock_closed.svg'))
         else:
             self.setIcon(QIcon(':lock_open.svg'))
+        
+        self.sigToggled.emit(checked)
     
     def setCheckable(self, checkable: bool):
         super().setCheckable(checkable)


### PR DESCRIPTION
This PR implements the feature request of #1185 and refactors code here and there. 

The logic now is to store the current view (z-proj or z-slice) only when the frame/position is actually visited (unless tools on the toolbar are used to specifically apply the current z-slice to future frames, etc.). 

If the lock button is checked, the view is taken from the widget selectors and stored for the current frame/position only if different from what is already stored. 

If the lock button is not checked, the view is taken from the stored dataframe and the widgets are updated accordingly. 